### PR TITLE
Thief Redux, part 1.

### DIFF
--- a/code/code/cmd/cmd_bash.cc
+++ b/code/code/cmd/cmd_bash.cc
@@ -359,15 +359,32 @@ int TBeing::bashSuccess(TBeing* victim, spellNumT skill, bool isHoldingShield,
   if (isHoldingShield && itemInSecondaryHand) {
     shieldDam += (int)((itemInSecondaryHand->getWeight() / 4.0) + 1.0);
 
-    if (itemInSecondaryHand->isSpiked() ||
-        itemInSecondaryHand->isObjStat(ITEM_SPIKED)) {
-      act("The spikes on your $o sink into $N.", FALSE, this,
+    if (itemInSecondaryHand->isSpiked() || itemInSecondaryHand->isObjStat(ITEM_SPIKED)) {
+       int spikeDam = :: number (1,4);
+      shieldDam += spikeDam;
+      wearSlotT limb = victim->getPartHit(this, false);
+      victim->addCurLimbHealth(limb, -spikeDam);
+      if (victim->isUndead() || victim->isImmune(IMMUNE_BLEED,limb) || victim->isLimbFlags(limb, PART_MISSING)) {
+      act("The spikes on your $o sink into $N's %s.", FALSE, this,
         itemInSecondaryHand, victim, TO_CHAR);
-      act("The spikes on $n's $o sink into $N.", FALSE, this,
+      act("The spikes on $n's $o sink into $N's %s.", FALSE, this,
         itemInSecondaryHand, victim, TO_NOTVICT);
-      act("The spikes on $n's $o sink into you.", FALSE, this,
+      act("The spikes on $n's $o sink into your %s.", FALSE, this,
         itemInSecondaryHand, victim, TO_VICT);
-      shieldDam += 2;
+      } else {
+      act("The spikes on your $o sink into $N's %s and open up a bloody wound!", FALSE, this,
+        itemInSecondaryHand, victim, TO_CHAR);
+      act("The spikes on $n's $o sink into $N's %s and open up a bloody wound! .", FALSE, this,
+        itemInSecondaryHand, victim, TO_NOTVICT);
+      act("The spikes on $n's $o sink into your %s and open up a bloody wound!", FALSE, this,
+        itemInSecondaryHand, victim, TO_VICT);
+      victim->rawBleed(limb, 250, SILENT_YES, CHECK_IMMUNITY_NO);
+      }
+      if (!::number(0,3)) {
+      itemInSecondaryHand->addToMaxStructPoints(-1);
+      itemInSecondaryHand->addToStructPoints(-spikeDam);
+      act("$o is damaged slightly as the spikes rip free.", false, this, itemInSecondaryHand, victim, TO_CHAR);
+      }
     }
   }
 

--- a/code/code/cmd/cmd_oldstab.cc
+++ b/code/code/cmd/cmd_oldstab.cc
@@ -1,0 +1,608 @@
+#include "handler.h"
+#include "being.h"
+#include "combat.h"
+#include "obj_general_weapon.h"
+#include "materials.h"
+#include "skills.h"
+
+//#define ALLOW_STAB_SEVER
+#define USE_NEW_STAB
+
+spellNumT doStabMsg(TBeing* tThief, TBeing* tSucker, TGenWeapon* tWeapon,
+  wearSlotT tLimb, int& tDamage, int tSever) {
+  const float tDamageValues[MAX_WEAR] = {
+    0.00,  // Nowhere
+    1.50,  // Head
+    1.10,  // Neck
+    1.05,  // Body
+    1.10,  // Back
+    0.90,  // Arm-R
+    0.90,  // Arm-L
+    0.80,  // Wrist-R
+    0.80,  // Wrist-L
+    0.40,  // Hand-R
+    0.40,  // Hand-L
+    0.20,  // Finger-R
+    0.20,  // Finger-L
+    1.20,  // Waist
+    1.10,  // Leg-R
+    1.10,  // Leg-L
+    0.30,  // Foot-R
+    0.30,  // Foot-L
+    0.00,  // Hold-R
+    0.00,  // Hold-L
+    1.10,  // Ex-Leg-R
+    1.10,  // Ex-Leg-L
+    0.30,  // Ex-Foot-R
+    0.30,  // Ex-Foot-L
+  };
+
+  spellNumT tDamageType = DAMAGE_NORMAL;
+
+  switch (tLimb) {
+    case WEAR_HEAD:
+      tDamageType = (!(rand() % 5) ? DAMAGE_CAVED_SKULL : SKILL_STABBING);
+      break;
+    case WEAR_NECK:
+      tDamageType = (!(rand() % 5) ? DAMAGE_BEHEADED : SKILL_STABBING);
+      break;
+    case WEAR_BODY:
+      tDamageType = DAMAGE_IMPALE;
+      break;
+    case WEAR_WAIST:
+      tDamageType = DAMAGE_DISEMBOWLED_VR;
+      break;
+    case WEAR_BACK:
+      tDamageType = SKILL_STABBING;
+      break;
+    default:
+      tDamageType = TYPE_STAB;
+      break;
+  }
+
+  // Basically damage is varied based on the limb here.
+  tDamage = (int)((float)tDamage * tDamageValues[tLimb]);
+
+  bool tKill = tThief->willKill(tSucker, tDamage, tDamageType, FALSE);
+
+  sstring tStLimb(tSucker->describeBodySlot(tLimb));
+  sstring tStringChar, tStringVict, tStringOthr, tStringMess;
+
+  if (tLimb == WEAR_HEAD && !(rand() % 99) &&
+      !tSucker->hasDisease(DISEASE_EYEBALL)) {
+    affectedData tAff;
+
+    tStringChar = "You glance $N's eyes with your $o, slicing them wide open!";
+    tStringVict =
+      "$n glances your eyes with $s $o, slicing them wide open!  YOUR BLIND!";
+    tStringOthr = "$n glances $N's eyes with $s $o, slicing them wide open!";
+
+    tAff.type = AFFECT_DISEASE;
+    tAff.level = 0;
+    tAff.duration = PERMANENT_DURATION;
+    tAff.modifier = DISEASE_EYEBALL;
+    tAff.location = APPLY_NONE;
+    tAff.bitvector = AFF_BLIND;
+    tSucker->affectTo(&tAff);
+    tSucker->rawBlind(tThief->GetMaxLevel(), tAff.duration, SAVE_NO);
+  } else
+    switch (::number(0, 5)) {
+      case 0:
+        tStringChar = format("You thrust your $o into $N's %s!") % tStLimb;
+        tStringVict = format("$n thrusts $s $o into your %s!") % tStLimb;
+        tStringOthr = format("$n thrusts $s $o into $N's %s!") % tStLimb;
+        break;
+
+      case 1:
+        tStringChar = format("You stab $N in $S %s!") % tStLimb;
+        tStringVict = format("$n stabs you in your %s!") % tStLimb;
+        tStringOthr = format("$n stabs $N in $S %s!") % tStLimb;
+        break;
+
+      case 2:
+        tStringChar = format("You gouge $N in $S %s!") % tStLimb;
+        tStringVict = format("$n gouges you in your %s!") % tStLimb;
+        tStringOthr = format("$n gouges $N in $S %s!") % tStLimb;
+
+      default:
+        tStringChar = format("You puncture $N's %s with your $o!") % tStLimb;
+        tStringVict = format("$n punctures your %s with $s $o!") % tStLimb;
+        tStringOthr = format("$n punctures $N's %s with $s $o!") % tStLimb;
+        break;
+    }
+
+  act(tStringChar, FALSE, tThief, tWeapon, tSucker, TO_CHAR);
+  act(tStringVict, FALSE, tThief, tWeapon, tSucker, TO_VICT);
+  act(tStringOthr, FALSE, tThief, tWeapon, tSucker, TO_NOTVICT);
+
+  if (tKill) {
+    switch (tLimb) {
+      case WEAR_HEAD:
+        if (tDamageType == SKILL_STABBING) {
+          tStringChar = "Your weapon sinks DEEP into $N's skull!";
+          tStringVict = "$n's weapon sinks DEEP into your skull!";
+          tStringOthr = "$n's weapon sinks DEEP into $N's skull!";
+        } else {
+          tStringChar = "You cause $N's skull to cave in!";
+          tStringVict = "$n caused your skull to cave in!";
+          tStringOthr = "$n caused $N's skull to cave in!";
+          tStringMess = "You get a good look at $N's grey matter...";
+        }
+
+        break;
+
+      case WEAR_NECK:
+        if (tDamageType == SKILL_STABBING) {
+          tStringChar = "You slice $N's neck wide open!";
+          tStringVict = "$n slices your neck wide open!";
+          tStringOthr = "$n slices $N's neck wide open!";
+          tStringMess = "Blood spews forth from $N's severed jugular!";
+        } else {
+          tStringChar = "You sever $N at the neck!";
+          tStringVict = "$n severs you at the neck!";
+          tStringOthr = "$n severs $N at the neck!";
+          tStringMess = "Blood gushes from $N's neck!";
+        }
+
+        break;
+
+      case WEAR_BODY:
+        if (!(rand() % 9)) {
+          tStringChar = "You thrust $p DEEP into $N's gut!";
+          tStringVict =
+            "$n thusts $p DEEP into your gut, good thing you are dead now!";
+          tStringOthr = "$n thrusts $p DEEP into $N's gut!";
+        } else {
+          tStringChar =
+            "You plunge $p DEEP into $N's chest, you can feel $S heart slow "
+            "then stop through your weapon";
+          tStringVict =
+            "$n plunges $p DEEP into your chest, piercing your heart!";
+          tStringOthr =
+            "$n plunges $p DEEP into $N's chest, looks like he nailed them in "
+            "the heart!";
+          tStringMess = "Blood spews forth from the stab wound!";
+        }
+
+        break;
+
+      case WEAR_WAIST:
+        tStringChar = "You slice $N from love handle to love handle!";
+        tStringVict = "$n slices you from love handle to love handle!";
+        tStringOthr = "$n slices $N from love handle to love handle!";
+        break;
+
+      case WEAR_BACK:
+        if (!(rand() % 9) && !tSucker->raceHasNoBones()) {
+          tStringChar = "You rake $p down $N's back, slicing the spine!";
+          tStringVict = "$n rakes $p down your back, slicing your spine!";
+          tStringOthr = "$n rakes $p down the back, slicing their spine!";
+        } else {
+          tStringChar = "You carve a rather nice hole in $N's back!";
+          tStringVict = "$n carves you a good sized hole in your back!";
+          tStringOthr = "$n carves $N a good sized hole in the back!";
+        }
+
+        break;
+
+      default:
+        tStringChar = format(
+                        "Your stab to $N's %s ends their life in a final "
+                        "<r>spray of blood<z>!") %
+                      tStLimb;
+        tStringVict = format(
+                        "$n stabs you in your %s, ending your life in a final "
+                        "<r>spray of blood<z>!") %
+                      tStLimb;
+        tStringOthr = format(
+                        "$n stabs $N in $S %s, ending their life in a final "
+                        "<r>spray of blood<z>!") %
+                      tStLimb;
+        break;
+    }
+
+    act(tStringChar, FALSE, tThief, tWeapon, tSucker, TO_CHAR);
+    act(tStringVict, FALSE, tThief, tWeapon, tSucker, TO_VICT);
+    act(tStringOthr, FALSE, tThief, tWeapon, tSucker, TO_NOTVICT);
+
+    if (!tStringMess.empty()) {
+      act(tStringMess, FALSE, tThief, tWeapon, tSucker, TO_CHAR);
+      act(tStringMess, FALSE, tThief, tWeapon, tSucker, TO_ROOM);
+    }
+
+    if (tLimb == WEAR_NECK) {
+      if (tDamageType == DAMAGE_BEHEADED)
+        tSucker->makeBodyPart(WEAR_HEAD, tThief);
+      else
+        tSucker->dropPool(50, LIQ_BLOOD);
+    }
+  } else {
+    // Apply some limb damage and have a *Very* remote chance of whacking the
+    // limb off.
+
+    int tHardness = material_nums[tSucker->getMaterial(tLimb)].hardness *
+                    tSucker->getCurLimbHealth(tLimb) /
+                    tSucker->getMaxLimbHealth(tLimb);
+    int tRc;
+
+    // This was mostly pulled from combat.cc:damageLimb()
+    if ((::number(1, (tSucker->getMaxLimbHealth(tLimb) / 4)) < tDamage) &&
+        (::number(1, 101) >= (tSucker->getConShock() / 3)) &&
+        (!tHardness || (::number(1, 101) >= (tHardness / 2)))) {
+      float tNewDamage = (tDamage * (25 + tThief->GetMaxLevel()));
+
+      tNewDamage /= 100;  // Make the damage *REAL* light
+      tNewDamage = std::max((float)0.0, tNewDamage);
+
+      // These limbs should be VERY difficult to damage with this.
+      if (tLimb == WEAR_HEAD || tLimb == WEAR_NECK || tLimb == WEAR_BODY ||
+          tLimb == WEAR_BACK || tLimb == WEAR_WAIST)
+        tNewDamage /= 10;
+
+      tRc = tSucker->hurtLimb((unsigned int)tNewDamage, tLimb);
+
+      if (IS_SET_DELETE(tRc, DELETE_THIS)) {
+        tDamage = -1;
+        return tDamageType;
+      }
+
+      // If weapon is poisoned, then toss that sucker in there!
+      // not bleeding  == poison victim
+      // limb bleeding == infect limb
+      for (int tSwingIndex = 0; tSwingIndex < MAX_SWING_AFFECT; tSwingIndex++) {
+        int tDuration = (tThief->GetMaxLevel() * Pulse::UPDATES_PER_MUDHOUR);
+
+        if (tWeapon->isPoisoned()) {
+          if (!tSucker->isLimbFlags(tLimb, PART_BLEEDING) &&
+              !tSucker->isAffected(AFF_POISON)) {
+            if (!tSucker->isImmune(IMMUNE_POISON, tLimb) && !::number(0, 9)) {
+              tWeapon->applyPoison(tSucker);
+
+              act("You poison $N with your stab!", FALSE, tThief, NULL, tSucker,
+                TO_CHAR);
+              act(
+                "You begin to feel strange, that bastard $n just poisoned you!",
+                FALSE, tThief, NULL, tSucker, TO_VICT);
+              act(
+                "$N gets a strange look on their face, apparently they are now "
+                "poisoned!",
+                FALSE, tThief, NULL, tSucker, TO_NOTVICT);
+            }
+          } else if (!tSucker->isLimbFlags(tLimb, PART_INFECTED))
+            if (!::number(0, 9) && tSucker->rawInfect(tLimb, tDuration,
+                                     SILENT_YES, CHECK_IMMUNITY_YES)) {
+              tStringChar =
+                format("Your stab to $N's %s infects it!") % tStLimb;
+              tStringVict =
+                format("Your %s gets infected from $n's stab!") % tStLimb;
+              tStringOthr =
+                format("$N's %s gets infected from $n's stab!") % tStLimb;
+
+              act(tStringChar, FALSE, tThief, NULL, tSucker, TO_CHAR);
+              act(tStringVict, FALSE, tThief, NULL, tSucker, TO_VICT);
+              act(tStringOthr, FALSE, tThief, NULL, tSucker, TO_NOTVICT);
+            }
+        }
+      }
+    } else {
+#if ALLOW_STAB_SEVER
+      // Here is where we check the tSever bit.
+      // Crit 3: 30 : 31 in 531
+      // Crit 2: 15 : 16 in 516
+      // Crit 1:  5 :  6 in 506
+      // Normal:  0 :  1 in 501
+
+      int tNewSever = (int)(((float)tSever * -tDamageValues[tLimb]) - 4.0);
+
+      // We further modify it based on the limb for a reason:
+      // Chance for whacking:
+      // Head   :  2 (can not be whacked)
+      // Neck   :  1 (can not be whacked)
+      // Body   :  1 (can not be whacked)
+      // Back   :  1 (can not be whacked)
+      // Arms   :  0 (can     be whacked)
+      // Waist :  2 (can not be whacked)
+      // Legs   :  1 (can not be whacked)
+      // Fingers: -4 (can     be whacked)
+      if (::number(tNewSever, 500) <= 0 &&
+          !tSucker->isLucky(tSucker->GetMaxLevel())) {
+        tStringChar = format("You slice $N's %s right off!") % tStLimb;
+        tStringVict = format("$n slices your %s right off!") % tStLimb;
+        tStringOthr="$n slices $N's %s right off!") % tStLimb;
+
+        tSucker->makePartMissing(tLimb, false, tThief);
+
+        act(tStringChar, FALSE, tThief, NULL, tSucker, TO_CHAR);
+        act(tStringVict, FALSE, tThief, NULL, tSucker, TO_VICT);
+        act(tStringOthr, FALSE, tThief, NULL, tSucker, TO_NOTVICT);
+      }
+#endif
+    }
+  }
+
+  return tDamageType;
+}
+
+static int stab(TBeing* thief, TBeing* victim) {
+  const int STAB_MOVE = 2;
+  int rc;
+  int level;
+
+  if (thief == victim) {
+    thief->sendTo("Hey now, let's not be stupid.\n\r");
+    return FALSE;
+  }
+  if (thief->checkPeaceful("Naughty, naughty.  None of that here.\n\r"))
+    return FALSE;
+
+  TGenWeapon* obj = dynamic_cast<TGenWeapon*>(thief->heldInPrimHand());
+  if (!obj) {
+    thief->sendTo("You need to wield a weapon, to make it a success.\n\r");
+    return FALSE;
+  }
+
+  if (thief->riding) {
+    thief->sendTo("Not while mounted!\n\r");
+    return FALSE;
+  }
+
+  if (dynamic_cast<TBeing*>(victim->riding)) {
+    thief->sendTo("Not while that person is mounted!\n\r");
+    return FALSE;
+  }
+
+  if (thief->noHarmCheck(victim))
+    return FALSE;
+
+  if (!obj->canStab()) {
+    act("You can't use $o to stab.", false, thief, obj, NULL, TO_CHAR);
+    return FALSE;
+  }
+
+  if (thief->getMove() < STAB_MOVE) {
+    thief->sendTo("You are too tired to stab.\n\r");
+    return FALSE;
+  }
+  /*
+  if (IS_SET(victim->specials.act, ACT_GHOST)) {
+    // mostly because kill is "you slit the throat", etc.
+    thief->sendTo("Ghosts can not be stabbed!\n\r");
+    return FALSE;
+  }
+  */
+
+  thief->addToMove(-STAB_MOVE);
+
+  thief->reconcileHurt(victim, 0.06);
+
+  level = thief->getSkillLevel(SKILL_STABBING);
+  int bKnown = thief->getSkillValue(SKILL_STABBING);
+
+  int dam = thief->getSkillDam(victim, SKILL_STABBING, level,
+    thief->getAdvLearning(SKILL_STABBING));
+  dam = thief->getActualDamage(victim, obj, dam, SKILL_STABBING);
+
+  int i = thief->specialAttack(victim, SKILL_STABBING);
+
+#ifdef USE_NEW_STAB
+  // Start of test stab-limb code.
+
+  wearSlotT tLimb = victim->getPartHit(thief, FALSE);
+  int tSever = 0;
+
+  if (!victim->hasPart(tLimb))
+    tLimb = victim->getCritPartHit();
+
+  if (!victim->awake() || (i && (i != GUARANTEED_FAILURE) &&
+                            thief->bSuccess(bKnown, SKILL_STABBING))) {
+    switch (critSuccess(thief, SKILL_STABBING)) {
+      case CRIT_S_KILL:
+        CS(SKILL_STABBING);
+        dam *= 4;
+        tSever = 30;
+        break;
+      case CRIT_S_TRIPLE:
+        CS(SKILL_STABBING);
+        dam *= 3;
+        tSever = 15;
+        break;
+      case CRIT_S_DOUBLE:
+        CS(SKILL_STABBING);
+        dam *= 2;
+        tSever = 5;
+        break;
+      case CRIT_S_NONE:
+        tSever = 0;
+        break;
+    }
+
+    spellNumT tDamageType = doStabMsg(thief, victim, obj, tLimb, dam, tSever);
+
+    // If they got nuked in doStabMsg then work with that.
+    if (dam == -1 || thief->reconcileDamage(victim, dam, tDamageType) == -1)
+      return DELETE_VICT;
+
+    if (obj->checkSpec(victim, CMD_STAB, reinterpret_cast<char*>(tLimb),
+          thief) == DELETE_VICT)
+      return DELETE_VICT;
+
+    return TRUE;
+  } else {
+    switch (critFail(thief, SKILL_STABBING)) {
+      case CRIT_F_HITSELF:
+      case CRIT_F_HITOTHER:
+        act("You over thrust and fall flat on your face!", FALSE, thief, obj,
+          victim, TO_CHAR);
+        act("$n misses $s thrust into $N and falls flat on their face!", FALSE,
+          thief, obj, victim, TO_NOTVICT);
+        act("$n misses $s thrust into you and falls flat on their face!", FALSE,
+          thief, obj, victim, TO_VICT);
+        rc = thief->crashLanding(POSITION_SITTING);
+
+        if (IS_SET_DELETE(rc, DELETE_THIS))
+          return DELETE_THIS;
+
+        break;
+      case CRIT_F_NONE:
+      default:
+        act("You miss your thrust into $N.", FALSE, thief, obj, victim,
+          TO_CHAR);
+        act("$n misses $s thrust into $N.", FALSE, thief, obj, victim,
+          TO_NOTVICT);
+        act("$n misses $s thrust into you.", FALSE, thief, obj, victim,
+          TO_VICT);
+        break;
+    }
+
+    thief->reconcileDamage(victim, 0, SKILL_STABBING);
+  }
+
+  return TRUE;
+
+  // End of test stab-limb code.
+#else
+  // Start of old stab code.
+
+  if (!victim->awake() || (i && (i != GUARANTEED_FAILURE) &&
+                            bSuccess(thief, bKnown, SKILL_STABBING))) {
+    switch (critSuccess(thief, SKILL_STABBING)) {
+      case CRIT_S_KILL:
+        if (!victim->getStuckIn(WEAR_BODY)) {
+          CS(SKILL_STABBING);
+          act("You thrust $p ***REALLY DEEP*** into $N and twist.", FALSE,
+            thief, obj, victim, TO_CHAR);
+          act("$n thrusts $p ***REALLY DEEP*** into $N and twists.", FALSE,
+            thief, obj, victim, TO_NOTVICT);
+          act("$n thrusts $p ***REALLY DEEP*** into you and twists it.", FALSE,
+            thief, obj, victim, TO_VICT);
+
+          dam *= 4;
+          act("You hit exceptionally well but lost your grasp on $p.", FALSE,
+            thief, obj, victim, TO_CHAR, ANSI_RED);
+          act("$n left $s $o stuck in you.", FALSE, thief, obj, victim, TO_VICT,
+            ANSI_ORANGE);
+          act("$n loses $s grasp on $p.", TRUE, thief, obj, victim, TO_NOTVICT);
+
+          rc =
+            victim->stickIn(thief->unequip(thief->getPrimaryHold()), WEAR_BODY);
+          if (IS_SET_DELETE(rc, DELETE_THIS))
+            return DELETE_VICT;
+          victim->rawBleed(WEAR_BODY, 150, SILENT_NO, CHECK_IMMUNITY_YES);
+          break;
+        }  // if already stuckIn, drop through to next
+      case CRIT_S_TRIPLE:
+        CS(SKILL_STABBING);
+        act("You thrust $p REALLY DEEP into $N and twist.", FALSE, thief, obj,
+          victim, TO_CHAR);
+        act("$n thrusts $p REALLY DEEP into $N and twists.", FALSE, thief, obj,
+          victim, TO_NOTVICT);
+        act("$n thrusts $p REALLY DEEP into you and twists it.", FALSE, thief,
+          obj, victim, TO_VICT);
+
+        dam *= 3;
+        break;
+      case CRIT_S_DOUBLE:
+        CS(SKILL_STABBING);
+        dam *= 2;
+        act("You thrust $p DEEP into $N and twist.", FALSE, thief, obj, victim,
+          TO_CHAR);
+        act("$n thrusts $p DEEP into $N and twists.", FALSE, thief, obj, victim,
+          TO_NOTVICT);
+        act("$n thrusts $p DEEP into you and twists it.", FALSE, thief, obj,
+          victim, TO_VICT);
+
+        break;
+      case CRIT_S_NONE:
+        act("You thrust $p into $N and twist.", FALSE, thief, obj, victim,
+          TO_CHAR);
+        act("$n thrusts $p into $N and twists.", FALSE, thief, obj, victim,
+          TO_NOTVICT);
+        act("$n thrusts $p into you and twists it.", FALSE, thief, obj, victim,
+          TO_VICT);
+
+        break;
+    }
+    if (thief->willKill(victim, dam, SKILL_STABBING, FALSE)) {
+      act("Your hand is coated in ichor as you slit $N's guts!", FALSE, thief,
+        obj, victim, TO_CHAR, ANSI_RED);
+      act(
+        "Ichor spews from the gaping stab wound $n leaves in $N's lifeless "
+        "body!",
+        TRUE, thief, obj, victim, TO_NOTVICT);
+    }
+
+    if (thief->reconcileDamage(victim, dam, SKILL_STABBING) == -1)
+      return DELETE_VICT;
+  } else {
+    switch (critFail(thief, SKILL_STABBING)) {
+      case CRIT_F_HITSELF:
+      case CRIT_F_HITOTHER:
+        CF(SKILL_STABBING);
+        act("You miss your thrust into $N and stab yourself.", FALSE, thief,
+          obj, victim, TO_CHAR);
+        act("$n misses $s thrust into $N and stabs $mself.", FALSE, thief, obj,
+          victim, TO_NOTVICT);
+        act("$n misses $s thrust into you and stabs $mself.", FALSE, thief, obj,
+          victim, TO_VICT);
+        if (thief->reconcileDamage(thief, dam / 3, SKILL_STABBING) == -1)
+          return DELETE_THIS;
+        break;
+      case CRIT_F_NONE:
+        act("You miss your thrust into $N.", FALSE, thief, obj, victim,
+          TO_CHAR);
+        act("$n misses $s thrust into $N.", FALSE, thief, obj, victim,
+          TO_NOTVICT);
+        act("$n misses $s thrust into you.", FALSE, thief, obj, victim,
+          TO_VICT);
+        thief->reconcileDamage(victim, 0, SKILL_STABBING);
+    }
+  }
+
+  // End of old stab code
+#endif
+
+  return TRUE;
+}
+
+int TBeing::doStab(const char* argument, TBeing* vict) {
+  TBeing* victim;
+  char namebuf[256];
+  int rc;
+
+  if (!doesKnowSkill(SKILL_STABBING)) {
+    sendTo("You haven't learned how to stab yet.\n\r");
+    return FALSE;
+  }
+  if (checkBusy()) {
+    return FALSE;
+  }
+  strcpy(namebuf, argument);
+
+  if (!(victim = vict)) {
+    if (!(victim = get_char_room_vis(this, namebuf))) {
+      if (!(victim = fight())) {
+        sendTo("Stab whom?\n\r");
+        return FALSE;
+      }
+    }
+  }
+  if (!sameRoom(*victim)) {
+    sendTo("That person isn't around.\n\r");
+    return FALSE;
+  }
+  if (IS_SET(victim->specials.act, ACT_IMMORTAL) || victim->isImmortal()) {
+    sendTo("Your stab attempt has no effect on your immortal target.\n\r");
+    return FALSE;
+  }
+  rc = stab(this, victim);
+  if (rc)
+    addSkillLag(SKILL_STABBING, rc);
+  if (IS_SET_DELETE(rc, DELETE_VICT)) {
+    if (vict)
+      return rc;
+    delete victim;
+    victim = NULL;
+    REM_DELETE(rc, DELETE_VICT);
+  }
+  return rc;
+}

--- a/code/code/cmd/cmd_sap.cc
+++ b/code/code/cmd/cmd_sap.cc
@@ -2,8 +2,8 @@
 #include "being.h"
 #include "combat.h"
 #include "obj_base_weapon.h"
-
-int TBeing::doSlam(const char* argument, TBeing* vict) {
+/*
+int TBeing::doSap(const char* argument, TBeing* vict) {
   int rc;
   TBeing* victim;
   const int SLAM_MOVE = 3;
@@ -13,7 +13,7 @@ int TBeing::doSlam(const char* argument, TBeing* vict) {
   }
 
   // Ensure player even knows the skill before continuing
-  if (!doesKnowSkill(SKILL_SLAM)) {
+  if (!doesKnowSkill(SKILL_SAP)) {
     sendTo(
       "You wouldn't even know where to begin in executing that maneuver.\n\r");
     return false;
@@ -32,14 +32,14 @@ int TBeing::doSlam(const char* argument, TBeing* vict) {
     return false;
   }
 
-  auto* weapon = dynamic_cast<TBaseWeapon*>(heldInPrimHand());
+  auto* weapon = dynamic_cast<TGenWeapon*>(heldInPrimHand());
 
   // Ensure this isn't a peaceful room
   if (checkPeaceful("You feel too peaceful to contemplate violence.\n\r"))
     return false;
 
   // Make sure the player has enough vitality to use the skill
-  if (getMove() < SLAM_MOVE) {
+  if (getMove() < SAP_MOVE) {
     sendTo("You don't have the vitality to make the move!\n\r");
     return false;
   }
@@ -78,9 +78,9 @@ int TBeing::doSlam(const char* argument, TBeing* vict) {
   if (!(isImmortal() || IS_SET(specials.act, ACT_IMMORTAL)))
     addToMove(-SLAM_MOVE);
 
-  int skillValue = getSkillValue(SKILL_SLAM);
-  int successfulHit = specialAttack(victim, SKILL_SLAM);
-  int successfulSkill = bSuccess(skillValue, SKILL_SLAM);
+  int skillValue = getSkillValue(SKILL_SAP);
+  int successfulHit = specialAttack(victim, SKILL_SAP);
+  int successfulSkill = bSuccess(skillValue, SKILL_SAP);
 
   // Success use case
   if (!victim->awake() || (successfulHit && successfulSkill &&
@@ -93,7 +93,7 @@ int TBeing::doSlam(const char* argument, TBeing* vict) {
   }
 
   if (rc)
-    addSkillLag(SKILL_SLAM, rc);
+    addSkillLag(SKILL_SAP, rc);
 
   if (IS_SET_DELETE(rc, DELETE_VICT)) {
     if (vict)
@@ -111,10 +111,10 @@ int TBeing::doSlam(const char* argument, TBeing* vict) {
 }
 
 int TBeing::slamSuccess(TBeing* victim) {
-  int skillLevel = getSkillLevel(SKILL_SLAM);
+  int skillLevel = getSkillLevel(SKILL_SAP);
   int dam =
-    getSkillDam(victim, SKILL_SLAM, skillLevel, getAdvLearning(SKILL_SLAM));
-  auto* weapon = dynamic_cast<TBaseWeapon*>(heldInPrimHand());
+    getSkillDam(victim, SKILL_SAP, skillLevel, getAdvLearning(SKILL_SAP));
+  auto* weapon = dynamic_cast<TGenWeapon*>(heldInPrimHand());
 
   // Scaling damage here due to the limitations of getSkillDam and how it treats
   // skills learned at low levels This formula is designed to allow the damage
@@ -139,20 +139,7 @@ int TBeing::slamSuccess(TBeing* victim) {
   dam = max((int)(victim->hitLimit() * scalingConstant), dam);
 
   // Send description text to players in the room
-  if (getCombatMode() == ATTACK_BERSERK) {
-    dam *= 2;
-    act(
-      "$n slams $N with $s weapon in a <R>berserk fury<z>, inflicting "
-      "considerable damage!",
-      FALSE, this, 0, victim, TO_NOTVICT);
-    act(
-      "You slam your weapon into $N in a <R>berserk fury<z>, inflicting "
-      "considerable damage!",
-      FALSE, this, 0, victim, TO_CHAR);
-    act("$n slams $s weapon into you with a <r>berserker's <z>zeal!", FALSE,
-      this, 0, victim, TO_VICT);
-
-  } else {
+  if  (){
     act("$n slams $N with $s weapon, inflicting considerable damage!", FALSE,
       this, 0, victim, TO_NOTVICT);
     act("You slam your weapon into $N, inflicting considerable damage!", FALSE,
@@ -164,20 +151,13 @@ int TBeing::slamSuccess(TBeing* victim) {
   // Determine damage type
   spellNumT damageType = DAMAGE_NORMAL;
 
-  if (weapon->isBluntWeapon())
-    damageType = DAMAGE_CAVED_SKULL;
-  else if (weapon->isPierceWeapon())
-    damageType = DAMAGE_IMPALE;
-  else if (weapon->isSlashWeapon())
-    damageType = DAMAGE_HACKED;
-  // Reconcile damage
   if (reconcileDamage(victim, dam, damageType) == -1)
     return DELETE_VICT;
 
   return true;
 }
 
-int TBeing::slamFail(TBeing* victim) {
+int TBeing::sapFail(TBeing* victim) {
   if (victim->getPosition() > POSITION_DEAD) {
     act(
       "$n's attempt at slamming $N's with $s his weapon fails to make contact.",
@@ -188,8 +168,9 @@ int TBeing::slamFail(TBeing* victim) {
       this, 0, victim, TO_VICT);
   }
 
-  if (reconcileDamage(victim, 0, SKILL_SLAM) == -1)
+  if (reconcileDamage(victim, 0, SKILL_SAP) == -1)
     return DELETE_VICT;
 
   return true;
 }
+*/

--- a/code/code/cmd/cmd_stab.cc
+++ b/code/code/cmd/cmd_stab.cc
@@ -5,77 +5,513 @@
 #include "materials.h"
 #include "skills.h"
 
-//#define ALLOW_STAB_SEVER
-#define USE_NEW_STAB
+#include "handler.h"
+#include "being.h"
+#include "combat.h"
+#include "obj_base_weapon.h"
 
-spellNumT doStabMsg(TBeing* tThief, TBeing* tSucker, TGenWeapon* tWeapon,
-  wearSlotT tLimb, int& tDamage, int tSever) {
-  const float tDamageValues[MAX_WEAR] = {
-    0.00,  // Nowhere
-    1.50,  // Head
-    1.10,  // Neck
-    1.05,  // Body
-    1.10,  // Back
-    0.90,  // Arm-R
-    0.90,  // Arm-L
-    0.80,  // Wrist-R
-    0.80,  // Wrist-L
-    0.40,  // Hand-R
-    0.40,  // Hand-L
-    0.20,  // Finger-R
-    0.20,  // Finger-L
-    1.20,  // Waist
-    1.10,  // Leg-R
-    1.10,  // Leg-L
-    0.30,  // Foot-R
-    0.30,  // Foot-L
-    0.00,  // Hold-R
-    0.00,  // Hold-L
-    1.10,  // Ex-Leg-R
-    1.10,  // Ex-Leg-L
-    0.30,  // Ex-Foot-R
-    0.30,  // Ex-Foot-L
-  };
+int TBeing::doStab(const char* argument, TBeing* vict) {
+  int rc;
+  TBeing* victim;
+  const int STAB_MOVE = 3;
 
-  spellNumT tDamageType = DAMAGE_NORMAL;
-
-  switch (tLimb) {
-    case WEAR_HEAD:
-      tDamageType = (!(rand() % 5) ? DAMAGE_CAVED_SKULL : SKILL_STABBING);
-      break;
-    case WEAR_NECK:
-      tDamageType = (!(rand() % 5) ? DAMAGE_BEHEADED : SKILL_STABBING);
-      break;
-    case WEAR_BODY:
-      tDamageType = DAMAGE_IMPALE;
-      break;
-    case WEAR_WAIST:
-      tDamageType = DAMAGE_DISEMBOWLED_VR;
-      break;
-    case WEAR_BACK:
-      tDamageType = SKILL_STABBING;
-      break;
-    default:
-      tDamageType = TYPE_STAB;
-      break;
+  if (checkBusy()) {
+    return false;
   }
 
-  // Basically damage is varied based on the limb here.
-  tDamage = (int)((float)tDamage * tDamageValues[tLimb]);
+  // Ensure player even knows the skill before continuing
+  if (!doesKnowSkill(SKILL_STABBING)) {
+    sendTo(
+      "You wouldn't even know where to begin in executing that maneuver.\n\r");
+    return false;
+  }
 
-  bool tKill = tThief->willKill(tSucker, tDamage, tDamageType, FALSE);
+  if (!(victim = vict)) {
+    if (!(victim = get_char_room_vis(this, argument))) {
+      if (!(victim = fight())) {
+        sendTo("Hit whom?\n\r");
+        return false;
+      }
+    }
+  }
+  if (!sameRoom(*victim)) {
+    sendTo("That person isn't around.\n\r");
+    return false;
+  }
 
-  sstring tStLimb(tSucker->describeBodySlot(tLimb));
-  sstring tStringChar, tStringVict, tStringOthr, tStringMess;
+  auto* weapon = dynamic_cast<TGenWeapon*>(heldInPrimHand());
 
-  if (tLimb == WEAR_HEAD && !(rand() % 99) &&
-      !tSucker->hasDisease(DISEASE_EYEBALL)) {
-    affectedData tAff;
+  // Ensure this isn't a peaceful room
+  if (checkPeaceful("You feel too peaceful to contemplate violence.\n\r"))
+    return false;
 
-    tStringChar = "You glance $N's eyes with your $o, slicing them wide open!";
-    tStringVict =
-      "$n glances your eyes with $s $o, slicing them wide open!  YOUR BLIND!";
-    tStringOthr = "$n glances $N's eyes with $s $o, slicing them wide open!";
+  // Make sure the player has enough vitality to use the skill
+  if (getMove() < STAB_MOVE) {
+    sendTo("You don't have the vitality to make the move!\n\r");
+    return false;
+  }
+
+  // Prevent players from attacking immortals
+  if (victim->isImmortal() || IS_SET(victim->specials.act, ACT_IMMORTAL)) {
+    sendTo("Attacking an immortal would be a bad idea.\n\r");
+    return false;
+  }
+
+  // Prevent players from attacking themselves
+  if (victim == this) {
+    sendTo("Do you REALLY want to kill yourself?...\n\r");
+    return false;
+  }
+
+  // Avoid players attacking un-harmable victims
+  if (noHarmCheck(victim))
+    return false;
+
+  // Limit players from using this while mounted
+  if (riding) {
+    sendTo("You can't perform that attack while mounted!\n\r");
+    return false;
+  }
+
+  // Ensure the player has a weapon equipped
+  if (!weapon) {
+    sendTo(
+      "You need to hold a weapon in your primary hand to make this a "
+      "success.\n\r");
+    return false;
+  }
+  if (!weapon->canStab()) {
+    act("You can't use $o to stab.", false, this, weapon, NULL, TO_CHAR);
+    return FALSE;
+  }
+  // Only consume vitality for mortals
+  if (!(isImmortal() || IS_SET(specials.act, ACT_IMMORTAL)))
+    addToMove(-STAB_MOVE);
+
+  int skillValue = getSkillValue(SKILL_STABBING);
+  int successfulHit = specialAttack(victim, SKILL_STABBING);
+  int successfulSkill = bSuccess(skillValue, SKILL_STABBING);
+
+  // Success use case
+  if (!victim->awake() || (successfulHit && successfulSkill &&
+                            successfulHit != GUARANTEED_FAILURE)) {
+    rc = slamSuccess(victim);
+  }
+  // Fail use case
+  else {
+    rc = slamFail(victim);
+  }
+
+  if (rc)
+    addSkillLag(SKILL_STABBING, rc);
+
+  if (IS_SET_DELETE(rc, DELETE_VICT)) {
+    if (vict)
+      return rc;
+    delete victim;
+    victim = nullptr;
+    REM_DELETE(rc, DELETE_VICT);
+  }
+
+  if (IS_SET_DELETE(rc, DELETE_THIS)) {
+    return DELETE_THIS;
+  }
+
+  return rc;
+}
+
+int TBeing::stabSuccess(TBeing* victim) {
+  int skillLevel = getSkillLevel(SKILL_STABBING);
+  int dam = getSkillDam(victim, SKILL_STABBING, skillLevel,
+    getAdvLearning(SKILL_STABBING));
+  auto* weapon = dynamic_cast<TGenWeapon*>(heldInPrimHand());
+
+  // Scaling damage here due to the limitations of getSkillDam and how it treats
+  // skills learned at low levels This formula is designed to allow the damage
+  // to scale up to 0.75% of max hp to have some effectiveness against high
+  // level opponents, while dealing a respectable amount of damage to lower
+  // level enemies
+  static const std::map<int, float> scalingDamageConstants = {{10, 0.15},
+    {20, 0.08}, {30, 0.05}, {40, 0.03}, {50, 0.02}};
+
+  // Default value for higher level enemies
+  float scalingConstant = 0.0075;
+
+  // For enemies level 1-50, retrieving
+  for (const auto& damageConstant : scalingDamageConstants) {
+    if (victim->GetMaxLevel() <= damageConstant.first) {
+      scalingConstant = damageConstant.second;
+      break;
+    }
+  }
+
+  // Apply the scaling constant
+  dam = max((int)(victim->hitLimit() * scalingConstant), dam);
+
+  wearSlotT limb = victim->getPartHit(this, false);
+  int limbdam = (weapon->getCurSharp() / 47) + (this->GetMaxLevel() / 22);
+  if (dynamic_cast<TObj*>(weapon)->isObjStat(ITEM_SPIKED)) {
+    limbdam = +1;
+  }
+
+  // Send description text to players in the room
+  if (!victim->isLimbFlags(limb, PART_MISSING) && !victim->isUndead() &&
+      !victim->isLimbFlags(limb, IMMUNE_BLEED)) {
+    int duration = (this->GetMaxLevel() * 3 + 200);
+    victim->rawBleed(limb, duration, SILENT_YES, CHECK_IMMUNITY_NO);
+    victim->hurtLimb(limbdam, limb);
+    act("You puncture $N's %s with your $o, leaving a bloody gash!", false,
+      this, weapon, victim, TO_CHAR);
+    act("$n punctures $N's %s with their $o, leaving a bloody gash!", false,
+      this, weapon, victim, TO_CHAR);
+    act("$n punctures your $s with their $o, leaving a bloody gash!!", false,
+      this, weapon, victim, TO_CHAR);
+  } else if (!victim->isLimbFlags(limb, PART_MISSING) &&
+             victim->isLimbFlags(limb, IMMUNE_BLEED)) {
+    act("You puncture $N's %s with your $o, leaving a gaping hole!", false,
+      this, weapon, victim, TO_CHAR);
+    act("$n punctures $N's %s with their $o, leaving a gaping hole!", false,
+      this, weapon, victim, TO_CHAR);
+    act("$n punctures your $s with their $o, leaving a gaping hole!!", false,
+      this, weapon, victim, TO_CHAR);
+
+  } else {
+    act("You stab $N's %s with your $o, leaving a big wound!", false, this,
+      weapon, victim, TO_CHAR);
+    act("$n stabs $N's %s with their $o, leaving a big wound!", false, this,
+      weapon, victim, TO_CHAR);
+    act("$n stab your $s with their $o, leaving a big wound!!", false, this,
+      weapon, victim, TO_CHAR);
+  }
+  if (weapon->isObjStat(ITEM_SPIKED)) {
+    weapon->addToCurSharp(-limbdam);
+    weapon->addToMaxStructPoints(-1);
+    weapon->addToStructPoints(-limbdam);
+    if (!victim->isLimbFlags(limb, IMMUNE_BLEED) && !victim->isUndead()) {
+      victim->rawBleed(limb, 250, SILENT_YES, CHECK_IMMUNITY_NO);
+      act(
+        "The wound begins to bleed as the spikes on $o shred flesh, but the "
+        "weapon is damaged!",
+        false, this, weapon, victim, TO_ROOM);
+    } else {
+      act(
+        "The wound becomes jagged as the spikes on $o rip through flesh, but "
+        "the weapon is damaged!",
+        false, this, weapon, victim, TO_ROOM);
+    }
+    victim->hurtLimb(1, limb);
+  }
+  if (!victim->isLimbFlags(limb, PART_MISSING) &&
+      ((victim->isLimbFlags(limb, PART_BLEEDING) ||
+        victim->isLimbFlags(limb, PART_INFECTED) ||
+        victim->isLimbFlags(limb, PART_BRUISED)))) {
+    if (victim->getCurLimbHealth(limb) >= victim->getMaxLimbHealth(limb) / 2) {
+      if (limb == WEAR_NECK || limb == WEAR_BODY || limb == WEAR_BACK ||
+          limb == WEAR_WAIST) {
+        return false;
+      } else if (limb == WEAR_HEAD && !victim->hasDisease(DISEASE_EYEBALL)) {
+        affectedData tAff;
+        act("You glance $N's eyes with your $o, slicing them wide open!", false,
+          this, 0, victim, TO_CHAR);
+        act("$n glances your eyes with $s $o, slicing them wide open!", false,
+          this, 0, victim, TO_VICT);
+        act("$n glances $N's eyes with $s $o, slicing them wide open!", false,
+          this, 0, victim, TO_NOTVICT);
+
+        tAff.type = AFFECT_DISEASE;
+        tAff.level = 0;
+        tAff.duration = PERMANENT_DURATION;
+        tAff.modifier = DISEASE_EYEBALL;
+        tAff.location = APPLY_NONE;
+        tAff.bitvector = AFF_BLIND;
+        victim->affectTo(&tAff);
+        victim->rawBlind(this->GetMaxLevel(), tAff.duration, SAVE_NO);
+      } else {
+        victim->makePartMissing(limb, false, this);
+        act("You slice $N's %s right off!", false, this, weapon, victim,
+          TO_CHAR);
+        act("$n slices your %s right off!", false, this, 0, victim, TO_VICT);
+        act("$n slices $N's %s right off!", false, this, 0, victim, TO_NOTVICT);
+      }
+
+      // Determine damage type
+      spellNumT damageType = DAMAGE_NORMAL;
+
+      if (weapon->isPierceWeapon())
+        damageType = DAMAGE_IMPALE;
+      // Reconcile damage
+      if (reconcileDamage(victim, dam, damageType) == -1)
+        return DELETE_VICT;
+      return true;
+    }
+  }
+
+  if (weapon->isPoisoned()) {
+    weapon->applyPoison(victim);
+    act("You poison $N with your stab!", false, this, NULL, victim, TO_CHAR);
+    act("That bastard $n just poisoned you!", false, this, NULL, victim,
+      TO_VICT);
+    act("$N gets a pale look on their face, like they've been poisoned!", false,
+      this, NULL, victim, TO_NOTVICT);
+  } else if (!victim->isLimbFlags(limb, PART_INFECTED) &&
+             victim->isLimbFlags(limb, PART_BLEEDING) && !::number(0, 4)) {
+    victim->rawInfect(limb, 250, SILENT_YES, CHECK_IMMUNITY_YES);
+    act("Your stab to $N's %s infects it!", false, this, NULL, victim, TO_CHAR);
+    act("Your %s gets infected from $n's stab!", false, this, NULL, victim,
+      TO_VICT);
+    act("$N's %s gets infected from $n's stab!", false, this, NULL, victim,
+      TO_NOTVICT);
+  }
+  spellNumT damageType = TYPE_PIERCE;
+
+  if (reconcileDamage(victim, dam, damageType) == -1)
+    return DELETE_VICT;
+
+  return true;
+}
+
+int TBeing::stabFailure(TBeing* victim) {
+  if (victim->getPosition() > POSITION_DEAD) {
+    act("You miss your thrust into $N.", FALSE, this, 0, victim, TO_CHAR);
+    act("$n misses $s thrust into $N.", FALSE, this, 0, victim, TO_NOTVICT);
+    act("$n misses $s thrust into you.", FALSE, this, 0, victim, TO_VICT);
+    this->reconcileDamage(victim, 0, SKILL_STABBING);
+  }
+
+  if (reconcileDamage(victim, 0, SKILL_STABBING) == -1)
+    {return DELETE_VICT;}
+
+  return true;
+}
+/*
+int TBeing::doStab(const char* argument, TBeing* thief, TBeing* vict,
+  TGenWeapon* weapon) {
+int rc;
+const int STAB_MOVE = 2;
+int level;
+TBeing* victim;
+
+  if (checkBusy()) {
+    return false;
+  }
+
+  // Ensure player even knows the skill before continuing
+  if (!doesKnowSkill(SKILL_STABBING)) {
+    sendTo(
+      "You simply do not have the training necessary to stab someone
+effectively.\n\r"); return false;
+  }
+
+  if (!(victim = vict)) {
+    if (!(victim = get_char_room_vis(this, argument))) {
+      if (!(victim = fight())) {
+        sendTo("Hit whom?\n\r");
+        return false;
+      }
+    }
+  }
+  if (!sameRoom(*victim)) {
+    sendTo("That person isn't around.\n\r");
+    return false;
+  }
+
+  auto* weapon = dynamic_cast<TGenWeapon*>(heldInPrimHand());
+
+  // Ensure this isn't a peaceful room
+  if (checkPeaceful("You feel too peaceful to contemplate violence.\n\r"))
+    return false;
+
+  // Make sure the player has enough vitality to use the skill
+  if (getMove() < STAB_MOVE) {
+    sendTo("You don't have the vitality to make the move!\n\r");
+    return false;
+  }
+
+  // Prevent players from attacking immortals
+  if (victim->isImmortal() || IS_SET(victim->specials.act, ACT_IMMORTAL)) {
+    sendTo("Attacking an immortal would be a bad idea.\n\r");
+    return false;
+  }
+
+  // Prevent players from attacking themselves
+  if (victim == this) {
+    sendTo("Do you REALLY want to kill yourself?...\n\r");
+    return false;
+  }
+
+  // Avoid players attacking un-harmable victims
+  if (noHarmCheck(victim))
+    return false;
+
+  // Limit players from using this while mounted
+  if (riding) {
+    sendTo("You can't perform that attack while mounted!\n\r");
+    return false;
+  }
+
+  // Ensure the player has a weapon equipped
+  if (!weapon) {
+    sendTo(
+      "You need to hold a weapon in your primary hand to do a stabbing.\n\r");
+    return false;
+  }
+    if (!weapon->canStab()) {
+      act("You can't use $o to stab.", false, thief, weapon, NULL, TO_CHAR);
+      return FALSE;
+    }
+
+    if (thief->riding) {
+      thief->sendTo("Not while mounted!\n\r");
+      return FALSE;
+    }
+
+    if (dynamic_cast<TBeing*>(victim->riding)) {
+      thief->sendTo("Not while that person is mounted!\n\r");
+      return FALSE;
+    }
+
+    if (thief->noHarmCheck(victim))
+      return FALSE;
+
+    if (thief->getMove() < STAB_MOVE) {
+      thief->sendTo("You are too tired to stab.\n\r");
+      return FALSE;
+    }
+
+    thief->addToMove(-STAB_MOVE);
+
+    thief->reconcileHurt(victim, 0.06);
+
+    level = thief->getSkillLevel(SKILL_STABBING);
+    int bKnown = thief->getSkillValue(SKILL_STABBING);
+  int skillLevel = getSkillLevel(SKILL_STABBING);
+  int skillValue = getSkillValue(SKILL_STABBING);
+  int successfulHit = specialAttack(victim, SKILL_STABBING);
+  int successfulSkill = bSuccess(skillValue, SKILL_STABBING);
+
+    int i = thief->specialAttack(victim, SKILL_STABBING);
+
+    // Success use case
+if (!victim->awake() || (successfulHit && successfulSkill &&
+                              successfulHit != GUARANTEED_FAILURE)) {
+  rc = stabSuccess(thief,victim, weapon);
+
+  // Fail use case
+ } else {
+    rc = stabFailure(thief,victim, weapon);
+  }
+
+  if (rc)
+    addSkillLag(SKILL_STABBING, rc);
+
+  if (IS_SET_DELETE(rc, DELETE_VICT)) {
+    if (vict)
+      return rc;
+    delete victim;
+    victim = nullptr;
+    REM_DELETE(rc, DELETE_VICT);
+  }
+
+  if (IS_SET_DELETE(rc, DELETE_THIS)) {
+    return DELETE_THIS;
+  }
+
+  return rc;
+}
+int TBeing::stabSuccess( TBeing* victim, TGenWeapon* weapon) {
+  int skillLevel = getSkillLevel(SKILL_STABBING);
+  int dam = getSkillDam(victim, SKILL_STABBING, skillLevel,
+getAdvLearning(SKILL_STABBING)); auto* weapon =
+dynamic_cast<TGenWeapon*>(heldInPrimHand()); wearSlotT limb =
+victim->getPartHit(thief, FALSE); int limbdam = (weapon->getCurSharp() / 47) +
+(this->GetMaxLevel() / 22); if (weapon->isObjStat(ITEM_SPIKED)()){ limbdam =+ 1;
+  }
+/// checking for the possibility of causing a bleed on victim
+  bool LimbCanBleed = !victim->isLimbFlags(limb, PART_MISSING) &&
+!victim->isUndead() && !victim->isLimbFlags(limb, IMMUNE_BLEED);  return
+LimbCanBleed;
+  }
+    /// checking to see if weapon is sharp and if mob is tough
+  bool LimbGetsHurt = !victim->isTough() &&
+(weapon->getCurSharp()>=weapon->getMaxSharp()); return LimbGetsHurt;
+  }
+  /// checking limb health and bleeding and bruising
+  bool LimbCanBeSevered = !victim->isLimbFlags(limb, PART_MISSING) &&
+(victim->isLimbFlags(limb, PART_BLEEDING) || victim->isLimbFlags(limb,
+PART_BRUISED)) && victim ->getCurHealt(limb) >= victim->(getMaxHealth(limb)/2));
+return LimbCanBeSevered;
+  }
+
+  /// if an object is SPIKED, then it will potentially be damaged, if it's a
+weapon, it will lose sharpness
+  }
+  if (weapon->isObjStat(ITEM_SPIKED)()) {
+   dam = +2;
+  }
+  ////now we mess up the limb and cause some bleeding. if the limb is bleeding
+  ///and half-wounded, cut it off!
+
+///mob fails save and has bleedable limbs
+if (limbsCanBleed(limb) && limbsCanGetHurt(limbs)) {
+   int duration = (thief->getMaxLevel() * 3 + 200));
+   victim->rawBleed(limb, duration, SILENT_YES, CHECK_IMMUNITY_NO);  }
+   int rc = vict->hurtLimb(limbdam, limb);
+   act("You puncture $N's %s with your $o, leaving a bloody gash!", false, this,
+weapon, victim TO_CHAR); act("$n punctures $N's %s with their $o, leaving a
+bloody gash!", false, this, weapon, victim TO_CHAR); act("$n punctures your $s
+with their $o, leaving a bloody gash!!", false, this, weapon, victim TO_CHAR);
+
+///mobs fails save and has no bleedable limbs
+} else if (
+ act("You puncture $N's %s with your $o, leaving a gaping hole!", false, this,
+weapon, victim TO_CHAR); act("$n punctures $N's %s with their $o, leaving a
+gaping hole!", false, this, weapon, victim TO_CHAR); act("$n punctures your $s
+with their $o, leaving a gaping hole!!", false, this, weapon, victim TO_CHAR);
+    if (weapon->isObjStat(ITEM_SPIKED)) {
+     weapon->addToCurSharp(-limbdam);
+     weapon->addToMaxStructPoints(-1);
+     weapon->addToStructPoints(-limbdam);
+     act("The wound becomes jagged as the spikes on $o rip through flesh, but
+the weapon is damaged!", false, thief, weapon, TO_ROOM);
+    }
+///mob succeeds save
+} else (
+   act("You stab $N's %s with your $o, leaving a big wound!", false, this,
+weapon, victim TO_CHAR); act("$n stabs $N's %s with their $o, leaving a big
+wound!", false, this, weapon, victim TO_CHAR); act("$n stab your $s with their
+$o, leaving a big wound!!", false, this, weapon, victim TO_CHAR);
+}
+
+    if (weapon->isObjStat(ITEM_SPIKED)() && && limbsCanBleed(limbs)) {
+     victim->rawBleed(limb, 250 SILENT_YES, CHECK_IMMUNITY_NO);
+     weapon->spikesBreak(victim, thief, weapon, limbdam);
+     act("Blood pours as the spikes on $o rip through flesh, but the weapon is
+damaged!", false, thief, weapon, TO_ROOM); } else if
+(weapon->isObjStat(ITEM_SPIKED)() && (victim->isImmune(IMMUNE_BLEEDING) ||
+victim->isUndead())){ weapon->addToCurSharp(-limbdam);
+       weapon->addToMaxStructPoints(-1);
+       weapon->addToStructPoints(-limbdam);
+
+    }
+}
+if (weapon->isObjStat(ITEM_SPIKED)) {
+     victim->rawBleed(limb, 250 SILENT_YES, CHECK_IMMUNITY_NO);
+  if(limbsCanBleed(limb)) {
+    spikesRip(victim, thief, weapon, limbdam);
+  }
+     act("Blood pours as the spikes on $o rip through flesh, but the weapon is
+damaged!", false, thief, weapon, TO_ROOM);
+    }
+
+)
+
+    if (!limb == WEAR_NECK || !limb == WEAR_BODY || !limb == WEAR_BACK || !limb
+== WEAR_WAIST){ return false; } else if (limb == WEAR_HEAD &&
+!tSucker->hasDisease(DISEASE_EYEBALL)) { affectedData tAff; act("You glance $N's
+eyes with your $o, slicing them wide open!",false, this, 0, victim) act("$n
+glances your eyes with $s $o, slicing them wide open!", false, this, 0, victim)
+    act("$n glances $N's eyes with $s $o, slicing them wide open!", false, this,
+0, victim)
 
     tAff.type = AFFECT_DISEASE;
     tAff.level = 0;
@@ -83,526 +519,70 @@ spellNumT doStabMsg(TBeing* tThief, TBeing* tSucker, TGenWeapon* tWeapon,
     tAff.modifier = DISEASE_EYEBALL;
     tAff.location = APPLY_NONE;
     tAff.bitvector = AFF_BLIND;
-    tSucker->affectTo(&tAff);
-    tSucker->rawBlind(tThief->GetMaxLevel(), tAff.duration, SAVE_NO);
-  } else
-    switch (::number(0, 5)) {
-      case 0:
-        tStringChar = format("You thrust your $o into $N's %s!") % tStLimb;
-        tStringVict = format("$n thrusts $s $o into your %s!") % tStLimb;
-        tStringOthr = format("$n thrusts $s $o into $N's %s!") % tStLimb;
-        break;
-
-      case 1:
-        tStringChar = format("You stab $N in $S %s!") % tStLimb;
-        tStringVict = format("$n stabs you in your %s!") % tStLimb;
-        tStringOthr = format("$n stabs $N in $S %s!") % tStLimb;
-        break;
-
-      case 2:
-        tStringChar = format("You gouge $N in $S %s!") % tStLimb;
-        tStringVict = format("$n gouges you in your %s!") % tStLimb;
-        tStringOthr = format("$n gouges $N in $S %s!") % tStLimb;
-
-      default:
-        tStringChar = format("You puncture $N's %s with your $o!") % tStLimb;
-        tStringVict = format("$n punctures your %s with $s $o!") % tStLimb;
-        tStringOthr = format("$n punctures $N's %s with $s $o!") % tStLimb;
-        break;
-    }
-
-  act(tStringChar, FALSE, tThief, tWeapon, tSucker, TO_CHAR);
-  act(tStringVict, FALSE, tThief, tWeapon, tSucker, TO_VICT);
-  act(tStringOthr, FALSE, tThief, tWeapon, tSucker, TO_NOTVICT);
-
-  if (tKill) {
-    switch (tLimb) {
-      case WEAR_HEAD:
-        if (tDamageType == SKILL_STABBING) {
-          tStringChar = "Your weapon sinks DEEP into $N's skull!";
-          tStringVict = "$n's weapon sinks DEEP into your skull!";
-          tStringOthr = "$n's weapon sinks DEEP into $N's skull!";
-        } else {
-          tStringChar = "You cause $N's skull to cave in!";
-          tStringVict = "$n caused your skull to cave in!";
-          tStringOthr = "$n caused $N's skull to cave in!";
-          tStringMess = "You get a good look at $N's grey matter...";
-        }
-
-        break;
-
-      case WEAR_NECK:
-        if (tDamageType == SKILL_STABBING) {
-          tStringChar = "You slice $N's neck wide open!";
-          tStringVict = "$n slices your neck wide open!";
-          tStringOthr = "$n slices $N's neck wide open!";
-          tStringMess = "Blood spews forth from $N's severed jugular!";
-        } else {
-          tStringChar = "You sever $N at the neck!";
-          tStringVict = "$n severs you at the neck!";
-          tStringOthr = "$n severs $N at the neck!";
-          tStringMess = "Blood gushes from $N's neck!";
-        }
-
-        break;
-
-      case WEAR_BODY:
-        if (!(rand() % 9)) {
-          tStringChar = "You thrust $p DEEP into $N's gut!";
-          tStringVict =
-            "$n thusts $p DEEP into your gut, good thing you are dead now!";
-          tStringOthr = "$n thrusts $p DEEP into $N's gut!";
-        } else {
-          tStringChar =
-            "You plunge $p DEEP into $N's chest, you can feel $S heart slow "
-            "then stop through your weapon";
-          tStringVict =
-            "$n plunges $p DEEP into your chest, piercing your heart!";
-          tStringOthr =
-            "$n plunges $p DEEP into $N's chest, looks like he nailed them in "
-            "the heart!";
-          tStringMess = "Blood spews forth from the stab wound!";
-        }
-
-        break;
-
-      case WEAR_WAIST:
-        tStringChar = "You slice $N from love handle to love handle!";
-        tStringVict = "$n slices you from love handle to love handle!";
-        tStringOthr = "$n slices $N from love handle to love handle!";
-        break;
-
-      case WEAR_BACK:
-        if (!(rand() % 9) && !tSucker->raceHasNoBones()) {
-          tStringChar = "You rake $p down $N's back, slicing the spine!";
-          tStringVict = "$n rakes $p down your back, slicing your spine!";
-          tStringOthr = "$n rakes $p down the back, slicing their spine!";
-        } else {
-          tStringChar = "You carve a rather nice hole in $N's back!";
-          tStringVict = "$n carves you a good sized hole in your back!";
-          tStringOthr = "$n carves $N a good sized hole in the back!";
-        }
-
-        break;
-
-      default:
-        tStringChar = format(
-                        "Your stab to $N's %s ends their life in a final "
-                        "<r>spray of blood<z>!") %
-                      tStLimb;
-        tStringVict = format(
-                        "$n stabs you in your %s, ending your life in a final "
-                        "<r>spray of blood<z>!") %
-                      tStLimb;
-        tStringOthr = format(
-                        "$n stabs $N in $S %s, ending their life in a final "
-                        "<r>spray of blood<z>!") %
-                      tStLimb;
-        break;
-    }
-
-    act(tStringChar, FALSE, tThief, tWeapon, tSucker, TO_CHAR);
-    act(tStringVict, FALSE, tThief, tWeapon, tSucker, TO_VICT);
-    act(tStringOthr, FALSE, tThief, tWeapon, tSucker, TO_NOTVICT);
-
-    if (!tStringMess.empty()) {
-      act(tStringMess, FALSE, tThief, tWeapon, tSucker, TO_CHAR);
-      act(tStringMess, FALSE, tThief, tWeapon, tSucker, TO_ROOM);
-    }
-
-    if (tLimb == WEAR_NECK) {
-      if (tDamageType == DAMAGE_BEHEADED)
-        tSucker->makeBodyPart(WEAR_HEAD, tThief);
-      else
-        tSucker->dropPool(50, LIQ_BLOOD);
-    }
-  } else {
-    // Apply some limb damage and have a *Very* remote chance of whacking the
-    // limb off.
-
-    int tHardness = material_nums[tSucker->getMaterial(tLimb)].hardness *
-                    tSucker->getCurLimbHealth(tLimb) /
-                    tSucker->getMaxLimbHealth(tLimb);
-    int tRc;
-
-    // This was mostly pulled from combat.cc:damageLimb()
-    if ((::number(1, (tSucker->getMaxLimbHealth(tLimb) / 4)) < tDamage) &&
-        (::number(1, 101) >= (tSucker->getConShock() / 3)) &&
-        (!tHardness || (::number(1, 101) >= (tHardness / 2)))) {
-      float tNewDamage = (tDamage * (25 + tThief->GetMaxLevel()));
-
-      tNewDamage /= 100;  // Make the damage *REAL* light
-      tNewDamage = std::max((float)0.0, tNewDamage);
-
-      // These limbs should be VERY difficult to damage with this.
-      if (tLimb == WEAR_HEAD || tLimb == WEAR_NECK || tLimb == WEAR_BODY ||
-          tLimb == WEAR_BACK || tLimb == WEAR_WAIST)
-        tNewDamage /= 10;
-
-      tRc = tSucker->hurtLimb((unsigned int)tNewDamage, tLimb);
-
-      if (IS_SET_DELETE(tRc, DELETE_THIS)) {
-        tDamage = -1;
-        return tDamageType;
-      }
-
-      // If weapon is poisoned, then toss that sucker in there!
-      // not bleeding  == poison victim
-      // limb bleeding == infect limb
-      for (int tSwingIndex = 0; tSwingIndex < MAX_SWING_AFFECT; tSwingIndex++) {
-        int tDuration = (tThief->GetMaxLevel() * Pulse::UPDATES_PER_MUDHOUR);
-
-        if (tWeapon->isPoisoned()) {
-          if (!tSucker->isLimbFlags(tLimb, PART_BLEEDING) &&
-              !tSucker->isAffected(AFF_POISON)) {
-            if (!tSucker->isImmune(IMMUNE_POISON, tLimb) && !::number(0, 9)) {
-              tWeapon->applyPoison(tSucker);
-
-              act("You poison $N with your stab!", FALSE, tThief, NULL, tSucker,
-                TO_CHAR);
-              act(
-                "You begin to feel strange, that bastard $n just poisoned you!",
-                FALSE, tThief, NULL, tSucker, TO_VICT);
-              act(
-                "$N gets a strange look on their face, apparently they are now "
-                "poisoned!",
-                FALSE, tThief, NULL, tSucker, TO_NOTVICT);
-            }
-          } else if (!tSucker->isLimbFlags(tLimb, PART_INFECTED))
-            if (!::number(0, 9) && tSucker->rawInfect(tLimb, tDuration,
-                                     SILENT_YES, CHECK_IMMUNITY_YES)) {
-              tStringChar =
-                format("Your stab to $N's %s infects it!") % tStLimb;
-              tStringVict =
-                format("Your %s gets infected from $n's stab!") % tStLimb;
-              tStringOthr =
-                format("$N's %s gets infected from $n's stab!") % tStLimb;
-
-              act(tStringChar, FALSE, tThief, NULL, tSucker, TO_CHAR);
-              act(tStringVict, FALSE, tThief, NULL, tSucker, TO_VICT);
-              act(tStringOthr, FALSE, tThief, NULL, tSucker, TO_NOTVICT);
-            }
-        }
-      }
+    victim->affectTo(&tAff);
+    victim->rawBlind(thief->GetMaxLevel(), tAff.duration, SAVE_NO);
+    } else if (victim->isBruised(limb) : victim->isBleeding(limb)) :
+victim->isUndead() : (victim->isImmune(IMMUNE_BLEEDING) &&
+victim->isImmune{IMMUNE_SKIN_COND)) && victim ->getCurHealt(limb) >=
+victim->(getMaxHealth(limb)/2){ victim->makePartMissing(limb, false, thief);
+    act("You slice $N's %s right off!", false, thief, weaopn, victim, TO_CHAR);
+    act("$n slices your %s right off!", false, this, 0, victim, TO_VICT);
+    act("$n slices $N's %s right off!", false, this, 0, victim, TO_NOTVICT);
     } else {
-#if ALLOW_STAB_SEVER
-      // Here is where we check the tSever bit.
-      // Crit 3: 30 : 31 in 531
-      // Crit 2: 15 : 16 in 516
-      // Crit 1:  5 :  6 in 506
-      // Normal:  0 :  1 in 501
+    return false;
+    }
 
-      int tNewSever = (int)(((float)tSever * -tDamageValues[tLimb]) - 4.0);
 
-      // We further modify it based on the limb for a reason:
-      // Chance for whacking:
-      // Head   :  2 (can not be whacked)
-      // Neck   :  1 (can not be whacked)
-      // Body   :  1 (can not be whacked)
-      // Back   :  1 (can not be whacked)
-      // Arms   :  0 (can     be whacked)
-      // Waist :  2 (can not be whacked)
-      // Legs   :  1 (can not be whacked)
-      // Fingers: -4 (can     be whacked)
-      if (::number(tNewSever, 500) <= 0 &&
-          !tSucker->isLucky(tSucker->GetMaxLevel())) {
-        tStringChar = format("You slice $N's %s right off!") % tStLimb;
-        tStringVict = format("$n slices your %s right off!") % tStLimb;
-        tStringOthr="$n slices $N's %s right off!") % tStLimb;
+              for (int tSwingIndex = 0; tSwingIndex < MAX_SWING_AFFECT;
+                 tSwingIndex++) {
+              int tDuration =
+                (tThief->GetMaxLevel() * Pulse::UPDATES_PER_MUDHOUR);
 
-        tSucker->makePartMissing(tLimb, false, tThief);
-
-        act(tStringChar, FALSE, tThief, NULL, tSucker, TO_CHAR);
-        act(tStringVict, FALSE, tThief, NULL, tSucker, TO_VICT);
-        act(tStringOthr, FALSE, tThief, NULL, tSucker, TO_NOTVICT);
+      if (weapon->isPoisoned()) {
+        weapon->applyPoison(victim);
+        act("You poison $N with your stab!", false, thief, NULL, victim,
+TO_CHAR); act("That bastard $n just poisoned you!", false, thief, NULL, victim,
+TO_VICT); act("$N gets a pale look on their face, like they  poisoned!",false,
+thief, NULL, victim, TO_NOTVICT); } else if (!victim->isLimbFlags(limb,
+PART_INFECTED)) && !::number(0, 4)){ victim->rawInfect(limb, tDuration,
+SILENT_YES, CHECK_IMMUNITY_YES)) { act("Your stab to $N's %s infects it!" false,
+thief, NULL, victim, TO_CHAR); act ("Your %s gets infected from $n's stab!")
+false, thief, NULL, victim, TO_VICT); act ("$N's %s gets infected from $n's
+stab!") false, thief, NULL, victim, TO_NOTVICT);
       }
-#endif
-    }
-  }
 
-  return tDamageType;
-}
 
-static int stab(TBeing* thief, TBeing* victim) {
-  const int STAB_MOVE = 2;
-  int rc;
-  int level;
 
-  if (thief == victim) {
-    thief->sendTo("Hey now, let's not be stupid.\n\r");
-    return FALSE;
-  }
-  if (thief->checkPeaceful("Naughty, naughty.  None of that here.\n\r"))
-    return FALSE;
+            if (dam == -1 ||
+                thief->reconcileDamage(victim, dam, tDamageType) == -1)
+              return DELETE_VICT;
 
-  TGenWeapon* obj = dynamic_cast<TGenWeapon*>(thief->heldInPrimHand());
-  if (!obj) {
-    thief->sendTo("You need to wield a weapon, to make it a success.\n\r");
-    return FALSE;
-  }
+            if (obj->checkSpec(victim, CMD_STAB, reinterpret_cast<char*>(limb),
+                  thief) == DELETE_VICT)
+              return DELETE_VICT;
 
-  if (thief->riding) {
-    thief->sendTo("Not while mounted!\n\r");
-    return FALSE;
-  }
+            return TRUE;
 
-  if (dynamic_cast<TBeing*>(victim->riding)) {
-    thief->sendTo("Not while that person is mounted!\n\r");
-    return FALSE;
-  }
-
-  if (thief->noHarmCheck(victim))
-    return FALSE;
-
-  if (!obj->canStab()) {
-    act("You can't use $o to stab.", false, thief, obj, NULL, TO_CHAR);
-    return FALSE;
-  }
-
-  if (thief->getMove() < STAB_MOVE) {
-    thief->sendTo("You are too tired to stab.\n\r");
-    return FALSE;
-  }
-  /*
-  if (IS_SET(victim->specials.act, ACT_GHOST)) {
-    // mostly because kill is "you slit the throat", etc.
-    thief->sendTo("Ghosts can not be stabbed!\n\r");
-    return FALSE;
-  }
-  */
-
-  thief->addToMove(-STAB_MOVE);
-
-  thief->reconcileHurt(victim, 0.06);
-
-  level = thief->getSkillLevel(SKILL_STABBING);
-  int bKnown = thief->getSkillValue(SKILL_STABBING);
-
-  int dam = thief->getSkillDam(victim, SKILL_STABBING, level,
-    thief->getAdvLearning(SKILL_STABBING));
-  dam = thief->getActualDamage(victim, obj, dam, SKILL_STABBING);
-
-  int i = thief->specialAttack(victim, SKILL_STABBING);
-
-#ifdef USE_NEW_STAB
-  // Start of test stab-limb code.
-
-  wearSlotT tLimb = victim->getPartHit(thief, FALSE);
-  int tSever = 0;
-
-  if (!victim->hasPart(tLimb))
-    tLimb = victim->getCritPartHit();
-
-  if (!victim->awake() || (i && (i != GUARANTEED_FAILURE) &&
-                            thief->bSuccess(bKnown, SKILL_STABBING))) {
-    switch (critSuccess(thief, SKILL_STABBING)) {
-      case CRIT_S_KILL:
-        CS(SKILL_STABBING);
-        dam *= 4;
-        tSever = 30;
-        break;
-      case CRIT_S_TRIPLE:
-        CS(SKILL_STABBING);
-        dam *= 3;
-        tSever = 15;
-        break;
-      case CRIT_S_DOUBLE:
-        CS(SKILL_STABBING);
-        dam *= 2;
-        tSever = 5;
-        break;
-      case CRIT_S_NONE:
-        tSever = 0;
-        break;
-    }
-
-    spellNumT tDamageType = doStabMsg(thief, victim, obj, tLimb, dam, tSever);
-
-    // If they got nuked in doStabMsg then work with that.
-    if (dam == -1 || thief->reconcileDamage(victim, dam, tDamageType) == -1)
-      return DELETE_VICT;
-
-    if (obj->checkSpec(victim, CMD_STAB, reinterpret_cast<char*>(tLimb),
-          thief) == DELETE_VICT)
-      return DELETE_VICT;
-
-    return TRUE;
-  } else {
-    switch (critFail(thief, SKILL_STABBING)) {
-      case CRIT_F_HITSELF:
-      case CRIT_F_HITOTHER:
-        act("You over thrust and fall flat on your face!", FALSE, thief, obj,
-          victim, TO_CHAR);
-        act("$n misses $s thrust into $N and falls flat on their face!", FALSE,
-          thief, obj, victim, TO_NOTVICT);
-        act("$n misses $s thrust into you and falls flat on their face!", FALSE,
-          thief, obj, victim, TO_VICT);
-        rc = thief->crashLanding(POSITION_SITTING);
-
-        if (IS_SET_DELETE(rc, DELETE_THIS))
-          return DELETE_THIS;
-
-        break;
-      case CRIT_F_NONE:
-      default:
-        act("You miss your thrust into $N.", FALSE, thief, obj, victim,
-          TO_CHAR);
-        act("$n misses $s thrust into $N.", FALSE, thief, obj, victim,
-          TO_NOTVICT);
-        act("$n misses $s thrust into you.", FALSE, thief, obj, victim,
-          TO_VICT);
-        break;
-    }
-
-    thief->reconcileDamage(victim, 0, SKILL_STABBING);
-  }
-
-  return TRUE;
-
-  // End of test stab-limb code.
-#else
-  // Start of old stab code.
-
-  if (!victim->awake() || (i && (i != GUARANTEED_FAILURE) &&
-                            bSuccess(thief, bKnown, SKILL_STABBING))) {
-    switch (critSuccess(thief, SKILL_STABBING)) {
-      case CRIT_S_KILL:
-        if (!victim->getStuckIn(WEAR_BODY)) {
-          CS(SKILL_STABBING);
-          act("You thrust $p ***REALLY DEEP*** into $N and twist.", FALSE,
-            thief, obj, victim, TO_CHAR);
-          act("$n thrusts $p ***REALLY DEEP*** into $N and twists.", FALSE,
-            thief, obj, victim, TO_NOTVICT);
-          act("$n thrusts $p ***REALLY DEEP*** into you and twists it.", FALSE,
-            thief, obj, victim, TO_VICT);
-
-          dam *= 4;
-          act("You hit exceptionally well but lost your grasp on $p.", FALSE,
-            thief, obj, victim, TO_CHAR, ANSI_RED);
-          act("$n left $s $o stuck in you.", FALSE, thief, obj, victim, TO_VICT,
-            ANSI_ORANGE);
-          act("$n loses $s grasp on $p.", TRUE, thief, obj, victim, TO_NOTVICT);
-
-          rc =
-            victim->stickIn(thief->unequip(thief->getPrimaryHold()), WEAR_BODY);
-          if (IS_SET_DELETE(rc, DELETE_THIS))
-            return DELETE_VICT;
-          victim->rawBleed(WEAR_BODY, 150, SILENT_NO, CHECK_IMMUNITY_YES);
-          break;
-        }  // if already stuckIn, drop through to next
-      case CRIT_S_TRIPLE:
-        CS(SKILL_STABBING);
-        act("You thrust $p REALLY DEEP into $N and twist.", FALSE, thief, obj,
-          victim, TO_CHAR);
-        act("$n thrusts $p REALLY DEEP into $N and twists.", FALSE, thief, obj,
-          victim, TO_NOTVICT);
-        act("$n thrusts $p REALLY DEEP into you and twists it.", FALSE, thief,
-          obj, victim, TO_VICT);
-
-        dam *= 3;
-        break;
-      case CRIT_S_DOUBLE:
-        CS(SKILL_STABBING);
-        dam *= 2;
-        act("You thrust $p DEEP into $N and twist.", FALSE, thief, obj, victim,
-          TO_CHAR);
-        act("$n thrusts $p DEEP into $N and twists.", FALSE, thief, obj, victim,
-          TO_NOTVICT);
-        act("$n thrusts $p DEEP into you and twists it.", FALSE, thief, obj,
-          victim, TO_VICT);
-
-        break;
-      case CRIT_S_NONE:
-        act("You thrust $p into $N and twist.", FALSE, thief, obj, victim,
-          TO_CHAR);
-        act("$n thrusts $p into $N and twists.", FALSE, thief, obj, victim,
-          TO_NOTVICT);
-        act("$n thrusts $p into you and twists it.", FALSE, thief, obj, victim,
-          TO_VICT);
-
-        break;
-    }
-    if (thief->willKill(victim, dam, SKILL_STABBING, FALSE)) {
-      act("Your hand is coated in ichor as you slit $N's guts!", FALSE, thief,
-        obj, victim, TO_CHAR, ANSI_RED);
-      act(
-        "Ichor spews from the gaping stab wound $n leaves in $N's lifeless "
-        "body!",
-        TRUE, thief, obj, victim, TO_NOTVICT);
-    }
-
-    if (thief->reconcileDamage(victim, dam, SKILL_STABBING) == -1)
-      return DELETE_VICT;
-  } else {
-    switch (critFail(thief, SKILL_STABBING)) {
-      case CRIT_F_HITSELF:
-      case CRIT_F_HITOTHER:
-        CF(SKILL_STABBING);
-        act("You miss your thrust into $N and stab yourself.", FALSE, thief,
-          obj, victim, TO_CHAR);
-        act("$n misses $s thrust into $N and stabs $mself.", FALSE, thief, obj,
-          victim, TO_NOTVICT);
-        act("$n misses $s thrust into you and stabs $mself.", FALSE, thief, obj,
-          victim, TO_VICT);
-        if (thief->reconcileDamage(thief, dam / 3, SKILL_STABBING) == -1)
-          return DELETE_THIS;
-        break;
-      case CRIT_F_NONE:
-        act("You miss your thrust into $N.", FALSE, thief, obj, victim,
-          TO_CHAR);
-        act("$n misses $s thrust into $N.", FALSE, thief, obj, victim,
-          TO_NOTVICT);
-        act("$n misses $s thrust into you.", FALSE, thief, obj, victim,
-          TO_VICT);
-        thief->reconcileDamage(victim, 0, SKILL_STABBING);
-    }
-  }
-
-  // End of old stab code
-#endif
-
-  return TRUE;
-}
-
-int TBeing::doStab(const char* argument, TBeing* vict) {
-  TBeing* victim;
-  char namebuf[256];
-  int rc;
-
-  if (!doesKnowSkill(SKILL_STABBING)) {
-    sendTo("You haven't learned how to stab yet.\n\r");
-    return FALSE;
-  }
-  if (checkBusy()) {
-    return FALSE;
-  }
-  strcpy(namebuf, argument);
-
-  if (!(victim = vict)) {
-    if (!(victim = get_char_room_vis(this, namebuf))) {
-      if (!(victim = fight())) {
-        sendTo("Stab whom?\n\r");
-        return FALSE;
-      }
-    }
-  }
-  if (!sameRoom(*victim)) {
-    sendTo("That person isn't around.\n\r");
-    return FALSE;
-  }
-  if (IS_SET(victim->specials.act, ACT_IMMORTAL) || victim->isImmortal()) {
-    sendTo("Your stab attempt has no effect on your immortal target.\n\r");
-    return FALSE;
-  }
-  rc = stab(this, victim);
-  if (rc)
-    addSkillLag(SKILL_STABBING, rc);
-  if (IS_SET_DELETE(rc, DELETE_VICT)) {
-    if (vict)
-      return rc;
-    delete victim;
-    victim = NULL;
-    REM_DELETE(rc, DELETE_VICT);
-  }
-  return rc;
-}
+            bool tKill = thief->willKill(victim, tDamage, tDamageType, false);
+return tKill;
+            }
+            if (thief->willKill(victim, dam, SKILL_STABBING, false)) {
+              act("Your hand is coated in ichor as you slit $N's guts!",
+false,thief, weapon, victim, TO_CHAR, ANSI_RED); act( "Ichor spews from the
+gaping stab wound in $N's lifeless body!", true, thief, weapon, victim,
+TO_NOTVICT); if (limb == WEAR_NECK) { victim->makeBodyPart(WEAR_HEAD, victim);
+                  victim->dropPool(50, LIQ_BLOOD);
+                  act(" $N's head rolls to a stop!", false, victim, NULL,
+victim, TO_ROOM);
+              }
+            }
+int TBeing::stabFailure(TBeing* thief, TBeing* victim, TGenWeapon* weapon)
+              act("You miss your thrust into $N.", FALSE, thief, obj, victim,
+                TO_CHAR);
+              act("$n misses $s thrust into $N.", FALSE, thief, obj, victim,
+                TO_NOTVICT);
+              act("$n misses $s thrust into you.", FALSE, thief, obj, victim,
+                TO_VICT);
+              thief->reconcileDamage(victim, 0, SKILL_STABBING);
+            }
+*/

--- a/code/code/disc/disc_murder.cc
+++ b/code/code/disc/disc_murder.cc
@@ -321,7 +321,8 @@ int backstab(TBeing* thief, TBeing* victim) {
     modifier += 5;
   if (thief->isAffected(AFF_HIDE))
     modifier += 5;
-
+  if (victim->fight() && !thief->fight())
+    modifier += 5;
   if (thief->makesNoise() && victim->awake()) {
     modifier -= 10;
 

--- a/code/code/misc/being.h
+++ b/code/code/misc/being.h
@@ -1970,8 +1970,12 @@ class TBeing : public TThing {
     int doDisguise(const char*);
     int doPoisonWeapon(sstring);
     int doGarrotte(const char*, TBeing*);
-    int doStab(const char*, TBeing*);
+    int doStab(const char* argument, TBeing* vict);
+    int stabSuccess(TBeing* victim);
+    int stabFailure(TBeing* victim);    
     int doCudgel(const char*, TBeing*);
+    int spikesHit(TBeing* victim, TBeing* ch, TObj* obj);
+    int spikesHitLimb(TBeing* victim, TBeing* ch, TObj* obj);
     virtual int moneyMeBeing(TThing* mon, TThing* sub);
     virtual unsigned int getTimer() const = 0;
     virtual void setTimer(unsigned int) = 0;

--- a/code/code/misc/body.h
+++ b/code/code/misc/body.h
@@ -11,7 +11,8 @@
 //  This is an attempt to make some sense out of the limb system.
 #pragma once
 
-#include "limbs.h"
+#include <cstring>
+void test(const char* str) {std::strlen(str);}
 
 const int MAX_SHEATH = 3;
 

--- a/code/code/misc/combat.cc
+++ b/code/code/misc/combat.cc
@@ -5298,6 +5298,9 @@ int TBeing::objDamage(spellNumT damtype, int amnt, TThing* t) {
 
   amnt = max(amnt, 0);
 
+  if (!isPc()) {
+    amnt *= 10;
+  }
   points.hit -= amnt;
   updatePos();
   rc = objDam(damtype, amnt, t);

--- a/code/code/misc/defs.h
+++ b/code/code/misc/defs.h
@@ -66,8 +66,9 @@ const unsigned short int PART_TRANSFORMED = (1 << 9);
 const unsigned short int PART_ENTANGLED = (1 << 10);
 const unsigned short int PART_BRUISED = (1 << 11);
 const unsigned short int PART_GANGRENOUS = (1 << 12);
+const unsigned short int PART_CORRODED = (1 << 13);
 
-const int MAX_PARTS = 12;  // move and change
+const int MAX_PARTS = 13;  // move and change
 
 /* 'class' for PC's */
 const unsigned short CLASS_MAGE = (1 << 0);      // 1

--- a/code/code/misc/disease_corrode.cc
+++ b/code/code/misc/disease_corrode.cc
@@ -1,0 +1,62 @@
+
+/*int disease_corrode(TBeing* victim, int message, affectedData* af) {
+  char buf[256];
+  wearSlotT slot = wearSlotT(af->level);
+  int level, dam, rc;
+
+  if (slot < MIN_WEAR || slot >= MAX_WEAR) {
+    vlogf(LOG_BUG, format("disease_corrode called with bad slot: %i") % slot);
+    return FALSE;
+  }
+  if (victim->isPc() && !victim->desc)
+    return FALSE;
+
+  switch (message) {
+    case DISEASE_BEGUN:
+      victim->addToLimbFlags(slot, PART_CORRODE);
+      break;
+    case DISEASE_PULSE:
+      // check to see if somehow the corroded bit got taken off (via spell)
+      if (!victim->hasPart(slot) || !victim->isLimbFlags(slot, PART_CORRODE)) {
+        af->duration = 0;
+        break;
+      }
+
+      }
+      if (!number(0, 10)) {
+        victim->sendTo(
+          format(
+            "Smoke rises from your %s as the <g>acid<1> corrodes you.\n\r") %
+          victim->describeBodySlot(slot));
+        sprintf(buf,
+          "$n's %s releases a plume of smoke as the <g>acid<1> burns them.",
+          victim->describeBodySlot(slot).c_str());
+        act(buf, TRUE, victim, NULL, NULL, TO_ROOM);
+        rc = victim->hurtLimb(1, slot);
+        if (IS_SET_DELETE(rc, DELETE_THIS))
+          return DELETE_THIS;
+        dam = ::number(3, 6);
+        if (victim->reconcileDamage(victim, dam, ACID_DAMAGE) == -1)
+          return DELETE_THIS;
+
+        if (dynamic_cast<TMonster*>(victim) && !victim->isPc())
+          (dynamic_cast<TMonster*>(victim))->UA((dam * 4));
+      }
+      victim->bodySpread(500, af);
+      break;
+    case DISEASE_DONE:
+      victim->remLimbFlags(slot, PART_CORRODE);
+      if (victim->getPosition() > POSITION_DEAD && victim->hasPart(slot)) {
+        victim->sendTo(format("The <g>acid<1> on your %s dissolves and stops smoking!\n\r") %
+                       victim->describeBodySlot(slot));
+        sprintf(buf, "The <g>acid<1> on $n's %s dissolves and stops smoking!",
+          victim->describeBodySlot(slot).c_str());
+        act(buf, TRUE, victim, NULL, NULL, TO_ROOM);
+      }
+
+      break;
+    default:
+      break;
+  }
+  return FALSE;
+}*/

--- a/code/code/misc/info.cc
+++ b/code/code/misc/info.cc
@@ -4748,6 +4748,10 @@ void TBeing::describeOtherFeatures(const TGenWeapon* obj, int learn) const {
       sendTo(COLOR_OBJECTS,
         format("%s seems small enough to be used for stabbing.\n\r") %
           sstring(capbuf).cap());
+    if (obj->isSpear())
+      sendTo(COLOR_OBJECTS,
+        format("%s seems like it could be used as a spear.\n\r") %
+          sstring(capbuf).cap());
     if (obj->canBackstab())
       sendTo(COLOR_OBJECTS, format("%s seems small enough to be used for "
                                    "backstabbing or throat slitting.\n\r") %

--- a/code/code/misc/offense.cc
+++ b/code/code/misc/offense.cc
@@ -1798,7 +1798,18 @@ int TBeing::frostEngulfed() {
   int i;
   int res;
   TThing* t = NULL;
-  // Need to account for worn containers
+  if (affectedBySpell(AFFECT_WET) && !isImmune(IMMUNE_COLD, WEAR_BODY)) {
+      affectedData af;
+      af.type = AFFECT_DISEASE;
+      af.level = 0;
+      af.duration = 200;
+      af.modifier = DISEASE_FROSTBITE;
+      af.location = APPLY_NONE;
+      af.bitvector = 0;
+      affectTo(&af);
+      disease_start(this, &af);
+  }
+    // Need to account for worn containers
   for (i = MIN_WEAR; i < MAX_WEAR; i++) {
     if (!(t = equipment[i]) || !(obj = dynamic_cast<TObj*>(t)))
       continue;

--- a/code/code/misc/parse.cc
+++ b/code/code/misc/parse.cc
@@ -104,8 +104,20 @@ bool willBreakHide(cmdTypeT tCmd, bool isPre) {
       return (isPre ? false : true);
     case CMD_SLIT:
       return (isPre ? false : true);
-
+    
+    ///rest is a special case. we don't want to break hide for it
+    ///this represents the PC's ability to remain alert
+    /// CMD_STAND is included to prevent hide from breaking when the thief
+    /// exits rest.
+    /// CMD_SIGN is meant to represent a 'thieves cant' means of communication
+    /// without revealing the thief's position, because it already requires that the PC be visible
+    /// CMD_PTELL is also included because it's meant to be silent
+    /// conceal, disguise, spy, sneak, and hide are also included as they are stealth-oriented thief abilities
+    case CMD_PTELL:
+    case CMD_REST:
+    case CMD_STAND:
     case CMD_LOOK:
+    case CMD_SIGN:
     case CMD_SCORE:
     case CMD_TROPHY:
     case CMD_INVENTORY:
@@ -119,6 +131,7 @@ bool willBreakHide(cmdTypeT tCmd, bool isPre) {
     case CMD_TIME:
     case CMD_HIDE:
     case CMD_SNEAK:
+    case CMD_CONCEAL:
     case CMD_QUEST:
     case CMD_LEVELS:
     case CMD_WIZLIST:

--- a/code/code/misc/room.cc
+++ b/code/code/misc/room.cc
@@ -473,3 +473,36 @@ TThing* TRoom::findInRoom(const std::function<bool(TThing*)>& predicate) {
   auto found = std::find_if(stuff.begin(), stuff.end(), predicate);
   return found != stuff.end() ? *found : nullptr;
 }
+
+
+bool TRoom::hasMobToCuddle() {
+  for (TThing* thing : stuff) {
+    auto* mob = dynamic_cast<TMonster*>(thing);
+    if (mob && (mob->getRace() == RACE_CANINE || mob->getRace() == RACE_FELINE)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+bool TRoom::hasCampfire() {
+  
+  for (auto* obj : stuff) {
+    auto* log = dynamic_cast<TOrganic*>(obj);
+    if (log && (log->getOType() = ORGANIC_WOOD) && (log->isObjStat(ITEM_BURNING()))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+TPool* TRoom::hasPool(liqTypeT liq) {
+  for (TThing* thing : stuff) {
+    auto* pool = dynamic_cast<TPool*>(thing);
+    if (pool && pool->getDrinkType() == liq) {
+      return pool;
+    }
+  }
+  return nullptr;
+}

--- a/code/code/misc/room.h
+++ b/code/code/misc/room.h
@@ -12,6 +12,7 @@
 #include "db.h"
 #include "thing.h"
 #include "obj.h"
+#include "obj_pool.h"
 
 class TRoom;
 
@@ -159,6 +160,7 @@ class TRoom : public TThing {
     const sstring& getDescr();
 
     int dropPool(int, liqTypeT);
+    bool hasPool(TPool* p,liqTypeT);
     void flameRoom();
     virtual int chiMe(TBeing*);
     int checkPointroll();
@@ -262,6 +264,11 @@ class TRoom : public TThing {
     int pitchBlackDark() { return getLight() <= 0; }
 
     TThing* findInRoom(const std::function<bool(TThing*)>&);
+    TPool* hasPool(liqTypeT liq);
+    bool TRoom:: hasMobToCuddle();
+    bool TRoom::hasCampfire();
+
+
 };
 
 const int ZONE_MAX_TIME = 50;

--- a/code/code/misc/spec_trap.cc
+++ b/code/code/misc/spec_trap.cc
@@ -1,0 +1,408 @@
+#include <vector>
+#include <unordered_set>
+#include "being.h"
+#include "room.h"
+#include "low.h"
+#include "extern.h"
+#include "monster.h"
+#include "obj.h"
+#include "obj_open_container.h"
+#include "obj_trap.h"
+#include "obj_arrow.h"
+#include "limbs.h"
+
+//// spike trap
+int trapBolt(int amt, TTrap* trap, TBeing*, TBeing* vict) {
+  //// embed spikes
+  std::vector<wearSlotT> validLimbs;
+  int maxNumLimbs = trap->getTrapLevel() / 3;
+  int numLimbs = ::number((maxNumLimbs / 3), maxNumLimbs);
+  int limbDam = ::number(trap->getTrapLevel() / 2, trap->getTrapLevel());
+  limbDam = limbDam * (vict->getImmunity(IMMUNE_PIERCE) / 100);
+  TObj* bolt = read_object(31349, REAL);
+
+  for (wearSlotT limb; limb < MAX_WEAR; limb++) {
+    // put particular checks here, pass through vict
+    if (vict->hasPart(limb) && !vict->getStuckIn(limb)) {
+      validLimbs.push_back(limb);
+    }
+  }
+
+  while (numLimbs > 0 && !validLimbs.empty()) {
+    unsigned int index = ::number(0, validLimbs.size() - 1);
+    wearSlotT limb = validLimbs[index];
+    /// do things to the limb here
+    if (vict->equipment[limb]) {
+      auto* eq = dynamic_cast<TObj*>(vict->equipment[limb]);
+      eq->addToStructPoints(-limbDam);
+      sstring buf = format("A bolt tears through $N's %s, damaging it!") %
+                    vict->equipment[limb];
+      act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_YELLOW);
+      buf = format("A bolt tears through your %s, damaging it!") %
+                    vict->equipment[limb];
+      act(buf, false, vict, nullptr, nullptr, TO_VICT, ANSI_YELLOW);
+    }
+    vict->stickIn(bolt, limb);
+    vict->addCurLimbHealth(limb, -limbDam);
+
+    sstring buf = format("A bolt embeds itself in $N's %s!") %
+                  vict->describeBodySlot(limb);
+    act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_ORANGE);
+    buf = format("A bolt embeds itself in your %s!") %
+                  vict->describeBodySlot(limb);
+    act(buf, false, vict, nullptr, nullptr, TO_VICT, ANSI_ORANGE);
+
+    /// do second part here within if statement
+    if (!vict->isTough() && !vict->isImmune(IMMUNE_BLEED, limb)) {
+      vict->rawBleed(limb, 250, SILENT_YES, CHECK_IMMUNITY_NO);
+      act("Blood begins to flow from the wound!", false, vict, nullptr, nullptr,
+        TO_ROOM, ANSI_RED_BOLD);
+      act("Blood begins to flow from the wound!", false, vict, nullptr, nullptr,
+        TO_CHAR, ANSI_RED_BOLD);
+    }
+    // back to vector stuff
+    --numLimbs;
+    if (index != validLimbs.size() - 1) {
+      std::swap(validLimbs[index], validLimbs.back());
+    }
+    validLimbs.pop_back();
+  }
+  return true;
+}
+
+int trapAcid(int amt, TTrap* trap, TBeing*, TBeing* vict) {
+  //// eat armor, equip glob of acid, does damage on pulse
+  int maxNumLimbs = trap->getTrapLevel() / 3;
+  int numLimbs = ::number((maxNumLimbs / 3), maxNumLimbs);
+  int limbDam = ::number(trap->getTrapLevel() / 5, trap->getTrapLevel() / 2.5);
+  limbDam = limbDam * (vict->getImmunity(IMMUNE_ACID) / 100);
+
+  TObj* glob = read_object(31349, REAL);
+
+  std::vector<wearSlotT> validLimbs;
+
+  for (wearSlotT limb; limb < MAX_WEAR; limb++) {
+    // check for specific limb conditions
+    if (vict->hasPart(limb) && !vict->equipment[limb] &&
+        !vict->getStuckIn(limb)) {
+      validLimbs.push_back(limb);
+    }
+  }
+
+  // Assuming you calculated the number of limbs to damage somehow previously
+  // and captured it in an int called `numLimbs` Do this until you've either
+  // damaged the max total number of limbs, or run out of valid target limbs
+  while (numLimbs > 0 && !validLimbs.empty()) {
+    unsigned int index = ::number(0, validLimbs.size() - 1);
+    wearSlotT limb = validLimbs[index];
+
+    vict->addCurLimbHealth(limb, -limbDam);
+    sstring buf =
+      format("Acid splashes onto $N's %s!") % vict->describeBodySlot(limb);
+    act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_GREEN_BOLD);
+    buf =
+      format("Acid splashes onto $N's %s!") % vict->describeBodySlot(limb);
+    act(buf, false, vict, nullptr, nullptr, TO_VICT, ANSI_GREEN_BOLD);
+
+    if (!vict->isAgile(0)) {
+      vict->equipChar(glob, limb, SILENT_YES);
+      buf = format("$N's %s is totally covered in a glob of acid!") %
+                    vict->describeBodySlot(limb);
+      act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_GREEN_BOLD);
+      buf = format("Your %s is totally covered in a glob of acid!") %
+                    vict->describeBodySlot(limb);
+      act(buf, false, vict, nullptr, nullptr, TO_VICT, ANSI_GREEN_BOLD);
+    }
+
+    // Reduce remaining limbs to damage before next loop
+    --numLimbs;
+
+    // Remove the limb damaged in this iteration from the vector so it can't be
+    // chosen again. It's way more efficient to just pop the last element off a
+    // vector, so if we didn't already randomly select the last element, swap
+    // the one we chose with the last one then pop it off the back.
+    if (index != validLimbs.size() - 1) {
+      std::swap(validLimbs[index], validLimbs.back());
+    }
+    validLimbs.pop_back();
+  }
+  return true;
+}
+int trapExplosive(int amt, TTrap* trap, TBeing*, TBeing* vict) {
+  //// eat armor, equip glob of acid, does damage on pulse
+  int maxNumLimbs = trap->getTrapLevel() / 3;
+  int numLimbs = ::number((maxNumLimbs / 3), maxNumLimbs);
+  int limbDam = ::number(trap->getTrapLevel() / 5, trap->getTrapLevel() / 2.5);
+  limbDam = limbDam * (vict->getImmunity(IMMUNE_ACID) / 100);
+
+  std::vector<wearSlotT> validLimbs;
+
+  for (wearSlotT limb; limb < MAX_WEAR; limb++) {
+    // Not sure of all the checks you'd need here
+    if (vict->hasPart(limb) && !vict->equipment[limb] &&
+        !vict->getStuckIn(limb)) {
+      validLimbs.push_back(limb);
+    }
+  }
+
+  // Assuming you calculated the number of limbs to damage somehow previously
+  // and captured it in an int called `numLimbs` Do this until you've either
+  // damaged the max total number of limbs, or run out of valid target limbs
+  while (numLimbs > 0 && !validLimbs.empty()) {
+    unsigned int index = ::number(0, validLimbs.size() - 1);
+    wearSlotT limb = validLimbs[index];
+
+    vict->addCurLimbHealth(limb, -limbDam);
+    sstring buf =
+      format("Acid splashes onto $N's %s!") % vict->describeBodySlot(limb);
+    act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_GREEN_BOLD);
+    buf =
+      format("Acid splashes onto $N's %s!") % vict->describeBodySlot(limb);
+    act(buf, false, vict, nullptr, nullptr, TO_VICT, ANSI_GREEN_BOLD);
+
+    TObj* shrapnel = read_object(31349, REAL);
+    shrapnel->addObjStat(ITEM_BURNING);
+    vict->stickIn(shrapnel, limb);
+    act("Flaming chunks of shrapnel explode outward from the trap!", false,
+      vict, 0, 0, TO_ROOM);
+    act("$n is hit directly by a chunk of debris, which embeds in $n flesh!",
+      false, vict, 0, 0, TO_NOTVICT);
+    act("You are hit by debris, which embeds into your flesh!", false, vict, 0,
+      0, TO_VICT);
+
+    // Reduce remaining limbs to damage before next loop
+    --numLimbs;
+
+    // Remove the limb damaged in this iteration from the vector so it can't be
+    // chosen again. It's way more efficient to just pop the last element off a
+    // vector, so if we didn't already randomly select the last element, swap
+    // the one we chose with the last one then pop it off the back.
+    if (index != validLimbs.size() - 1) {
+      std::swap(validLimbs[index], validLimbs.back());
+    }
+    validLimbs.pop_back();
+  }
+  return true;
+}
+
+int trapFrost(int amt, TTrap* trap, TBeing*, TBeing* vict) {
+  //// eat armor, equip glob of acid, does damage on pulse
+  int maxNumLimbs = trap->getTrapLevel() / 3;
+  int numLimbs = ::number((maxNumLimbs / 3), maxNumLimbs);
+  int limbDam = ::number(trap->getTrapLevel() / 5, trap->getTrapLevel() / 2.5);
+  limbDam = limbDam * (vict->getImmunity(IMMUNE_COLD) / 100);
+
+  TObj* icicle = read_object(31349, REAL);
+
+  std::vector<wearSlotT> validLimbs;
+
+  for (wearSlotT limb; limb < MAX_WEAR; limb++) {
+    // Not sure of all the checks you'd need here
+    if (vict->hasPart(limb) && !vict->equipment[limb] &&
+        !vict->getStuckIn(limb)) {
+      validLimbs.push_back(limb);
+    }
+  }
+
+  // Assuming you calculated the number of limbs to damage somehow previously
+  // and captured it in an int called `numLimbs` Do this until you've either
+  // damaged the max total number of limbs, or run out of valid target limbs
+  while (numLimbs > 0 && !validLimbs.empty()) {
+    unsigned int index = ::number(0, validLimbs.size() - 1);
+    wearSlotT limb = validLimbs[index];
+    if (vict->equipment[limb]) {
+      auto* eq = dynamic_cast<TObj*>(vict->equipment[limb]);
+      eq->addToStructPoints(-limbDam);
+      sstring buf =
+        format("A shard of ice tears through $N's %s, damaging it!") %
+        vict->equipment[limb];
+      act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_WHITE_BOLD);
+      buf =
+        format("A shard of ice tears through your %s, damaging it!") %
+        vict->equipment[limb];
+      act(buf, false, vict, nullptr, nullptr, TO_VICT, ANSI_WHITE_BOLD);
+    } else {
+      vict->addCurLimbHealth(limb, -limbDam);
+      sstring buf =
+        format("A shard of ice tears through $N's %s, damaging it!") %
+        vict->describeBodySlot(limb);
+      act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_WHITE_BOLD);
+      buf =
+        format("A shard of ice tears through your %s, damaging it!") %
+        vict->describeBodySlot(limb);
+      act(buf, false, vict, nullptr, nullptr, TO_VICT, ANSI_WHITE_BOLD);
+      if (!vict->isImmune(IMMUNE_COLD, WEAR_BODY)) {
+        vict->stickIn(icicle, limb);
+        buf = format("A icicle embeds itself in $N's %s!") %
+                      vict->describeBodySlot(limb);
+        act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_BLUE_BOLD);
+        buf = format("An icicle embeds itself in your %s!") %
+                      vict->describeBodySlot(limb);
+        act(buf, false, vict, nullptr, nullptr, TO_VICT, ANSI_BLUE_BOLD);
+      }
+    }
+
+    // Reduce remaining limbs to damage before next loop
+    --numLimbs;
+
+    // Remove the limb damaged in this iteration from the vector so it can't be
+    // chosen again. It's way more efficient to just pop the last element off a
+    // vector, so if we didn't already randomly select the last element, swap
+    // the one we chose with the last one then pop it off the back.
+    if (index != validLimbs.size() - 1) {
+      std::swap(validLimbs[index], validLimbs.back());
+    }
+    validLimbs.pop_back();
+  }
+  return true;
+}
+int trapFire(int amt, TTrap* trap, TBeing*, TBeing* vict) {
+  std::vector<wearSlotT> validLimbs;
+  int level = trap->getTrapLevel();
+  int maxNumLimbs = trap->getTrapLevel() / 3;
+  int numLimbs = ::number((maxNumLimbs / 3), maxNumLimbs);
+  int limbDam = ::number(trap->getTrapLevel() / 5, trap->getTrapLevel() / 2.5);
+  limbDam = limbDam * (vict->getImmunity(IMMUNE_PIERCE) / 100);
+
+  for (wearSlotT limb; limb < MAX_WEAR; limb++) {
+    // put particular checks here, pass through vict
+    if (vict->hasPart(limb) && !vict->isImmune(IMMUNE_HEAT, limb)) {
+      validLimbs.push_back(limb);
+    }
+  }
+
+  while (numLimbs > 0 && !validLimbs.empty()) {
+    unsigned int index = ::number(0, validLimbs.size() - 1);
+    wearSlotT limb = validLimbs[index];
+    /// do things to the limb here
+    if (!vict->equipment[limb]) {
+      vict->addCurLimbHealth(limb, -limbDam);
+
+      sstring buf = format("Blazing tongues of fire burn $N's %s!") %
+                    vict->describeBodySlot(limb);
+      act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_ORANGE);
+      buf = format("Blazing tongues of fire burn your %s!") %
+                    vict->describeBodySlot(limb);
+      act(buf, false, vict, nullptr, nullptr, TO_VICT, ANSI_ORANGE);
+      if (!vict->isImmune(IMMUNE_HEAT, limb) && !vict->isAgile(0)) {
+        int burnLev = ::number(1, level / 3);
+        affectedData af1;
+        af1.type = SPELL_FIRE_BREATH;
+        af1.level = level;
+        af1.duration = (3 + (level / 2)) * Pulse::UPDATES_PER_MUDHOUR;
+        af1.location = APPLY_IMMUNITY;
+        af1.modifier = IMMUNE_HEAT;
+        af1.modifier2 = burnLev;
+        af1.bitvector = 0;
+              buf = format("$N's %s begins to crack and char from the heat!") %
+                    vict->describeBodySlot(limb);
+      act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_GRAY);
+      buf = format("Your %s begins to crack and char from the heat!") %
+                    vict->describeBodySlot(limb);
+      }
+      if (!vict->isPerceptive() && limb == WEAR_HEAD &&
+          vict->hasDisease(DISEASE_EYEBALL)) {
+        affectedData af;
+        af.type = AFFECT_DISEASE;
+        af.level = 0;  // has to be 0 for doctor to treat
+        af.duration = PERMANENT_DURATION;
+        af.modifier = DISEASE_EYEBALL;
+        af.location = APPLY_NONE;
+        af.bitvector = AFF_BLIND;
+        vict->affectTo(&af);
+        vict->rawBlind((level), af.duration, SAVE_NO);
+        act("$N is blinded by the heat!", false, vict, nullptr, nullptr,
+          TO_ROOM, ANSI_YELLOW_BOLD);
+        act("The world goes black in a flash as you are blinded by the heat!",
+          false, vict, nullptr, nullptr, TO_VICT, ANSI_YELLOW_BOLD);
+      }
+      // back to vector stuff
+      --numLimbs;
+      if (index != validLimbs.size() - 1) {
+        std::swap(validLimbs[index], validLimbs.back());
+      }
+      validLimbs.pop_back();
+    }
+  }
+  return true;
+}
+int trapPower(int amt, TTrap* trap, TBeing*, TBeing* vict) {
+  std::vector<wearSlotT> validLimbs;
+  int level = trap->getTrapLevel();
+  int maxNumLimbs = trap->getTrapLevel() / 3;
+  int numLimbs = ::number((maxNumLimbs / 3), maxNumLimbs);
+  int limbDam = ::number(trap->getTrapLevel() / 5, trap->getTrapLevel() / 2.5);
+  limbDam = limbDam * (vict->getImmunity(IMMUNE_ENERGY) / 100);
+
+  for (wearSlotT limb; limb < MAX_WEAR; limb++) {
+    // put particular checks here, pass through vict
+    if (vict->hasPart(limb) && !vict->isImmune(IMMUNE_ENERGY, limb)) {
+      validLimbs.push_back(limb);
+    }
+  }
+
+  while (numLimbs > 0 && !validLimbs.empty()) {
+    unsigned int index = ::number(0, validLimbs.size() - 1);
+    wearSlotT limb = validLimbs[index];
+    /// do things to the limb here
+    if (!vict->equipment[limb]) {
+      limbDam =+ limbDam; ;
+
+      sstring buf = format("Bolts of arcane energy surge through $N's %s!") %
+                    vict->describeBodySlot(limb);
+      act(buf, false, vict, nullptr, nullptr, TO_ROOM, ANSI_PURPLE_BOLD);
+      buf = format("Bolts of arcane energy surge through your %s!") %
+                    vict->describeBodySlot(limb);
+      act(buf, false, vict, nullptr, nullptr, TO_VICT, ANSI_PURPLE_BOLD);
+      if (!vict->isImmune(IMMUNE_ENERGY, limb) && (!vict->isWise() || !vict->isIntelligent())) {
+        int zapLev = ::number(1, level / 3);
+        affectedData af1;
+        af1.type = SPELL_ATOMIZE;
+        af1.level = level;
+        af1.duration = (3 + (level / 2)) * Pulse::UPDATES_PER_MUDHOUR;
+        af1.location = APPLY_IMMUNITY;
+        af1.modifier = IMMUNE_ENERGY;
+        af1.modifier2 = zapLev;
+        af1.bitvector = 0;        
+      }
+      
+      // back to vector stuff
+      --numLimbs;
+      if (index != validLimbs.size() - 1) {
+        std::swap(validLimbs[index], validLimbs.back());
+      }
+      validLimbs.pop_back();
+    }
+  }
+  int headStr = vict->getCurLimbHealth(WEAR_HEAD);
+  genericCurse(nullptr, vict, 50, SPELL_CURSE);
+  if (headStr <= limbDam) {
+  affectedData aff;
+  aff.type = SPELL_PARALYZE;
+  aff.level = level;
+  aff.location = APPLY_NONE;
+  aff.bitvector = AFF_PARALYSIS;
+  aff.modifier = 0;
+
+  // balance notes, each "duration" is a complete round out of action
+  // to compare to other spell damages, we assume mob does 1.20 * lev
+  // dam per round
+  // clerics ought to be doing 1.60 * lev dam per round.
+  // theoretically, that means paralyze ought to be 4/3 * difficulty
+  // modifier of 100/60 = 20/9 = 2.25
+  // anyway, lets bump it up to 3 rounds
+  aff.duration = level/3;
+  }
+  return true;
+}
+
+/*
+
+
+int trapBolt(int amt, TBeing*, TBeing* vict) {}
+//// embed bolt
+int trapPebble(int amt, TBeing*, TBeing* vict) {}
+//// limb damage, apply bruise
+int trapPower(int amt, TBeing*, TBeing* vict) {}
+//// apply curse
+*/

--- a/code/code/misc/spikes.cc
+++ b/code/code/misc/spikes.cc
@@ -1,0 +1,101 @@
+
+#include <stdio.h>
+
+#include <cmath>
+
+#include "discipline.h"
+#include "handler.h"
+#include "extern.h"
+#include "immunity.h"
+#include "room.h"
+#include "being.h"
+#include "client.h"
+#include "low.h"
+#include "colorstring.h"
+#include "monster.h"
+#include "configuration.h"
+#include "materials.h"
+#include "range.h"
+#include "combat.h"
+#include "statistics.h"
+#include "person.h"
+#include "disease.h"
+#include "mail.h"
+#include "shop.h"
+#include "database.h"
+#include "obj_money.h"
+#include "obj_trash.h"
+#include "obj_arrow.h"
+#include "obj_general_weapon.h"
+#include "obj_base_weapon.h"
+#include "obj_gun.h"
+#include "obj_handgonne.h"
+#include "obj_base_clothing.h"
+#include "cmd_trophy.h"
+#include "obj_base_cup.h"
+#include "rent.h"
+#include "stats.h"
+/*
+/// checking for the possibility of causing a bleed on victim
+  bool LimbCanBleed = !victim->isLimbFlag(limb, PART_MISSING) && !victim->isUndead() && !victim->isImmune(IMMUNE_BLEED, limb);  return LimbCanBleed;
+  }
+    /// checking to see if weapon is sharp and if mob is tough
+  bool LimbGetsHurt = !victim->isTough() && (weapon->getCurSharp()>=weapon->getMaxSharp()); return LimbGetsHurt;
+  }
+  /// checking limb health and bleeding and bruising
+  bool LimbCanBeSevered = !victim->isLimbFlag(limb, PART_MISSING) && (victim->isLimbFlag(limb, PART_BLEEDING) || victim->isLimbFlag(limb, PART_BRUISED)) && victim ->getCurHealt(limb) >= victim->(getMaxHealth(limb)/2)); return LimbCanBeSevered;
+  }
+
+int spikesHit(TBeing* victim, TBeing* ch, TObj* obj) {
+   if (!victim)
+    return false;
+   bool LimbCanBleed = !victim->isLimbFlag(limb, PART_MISSING) && !victim->isUndead() && !victim->isImmune(IMMUNE_BLEED, limb);  return LimbCanBleed;
+  }
+  if (victim->LimbCanBleed(limb) &&)(obj->isObjStat(ITEM_SPIKED)){
+  victim->rawBleed(limb, 250, SILENT_YES, CHECK_IMMUNITY_NO);
+  act("A <r>bloody wound<1> opens as the spikes on $o shred $N's %s!", false, ch, obj, victim, TO_NOTVICT);
+  act("A <r>bloody wound<1> opens as the spikes on $o shred your $s!", false, ch, obj, victim, TO_VICT);
+  }
+  return false;
+}
+
+int spikesHitLimb(TBeing* victim, TBeing* ch, TObj* obj) {
+  wearSlotT limb = vict->getPartHit(ch, false);
+  if (limb == WEAR_NONE)
+    return false;
+  if (victim->LimbCanBleed(limb) &&)(obj->isObjStat(ITEM_SPIKED)) (
+  victim->rawBleed(limb, 250, SILENT_YES, CHECK_IMMUNITY_NO);
+  act("A <r>bloody wound<1> opens as the spikes on $o shred $N's %s!", false, ch, obj, victim, TO_NOTVICT);
+  act("A <r>bloody wound<1> opens as the spikes on $o shred your $s!", false, ch, obj, victim, TO_VICT);
+  )
+  return false;
+}
+  int spikesBreak(TBeing* victim, TBeing* thief, TObj* obj) {
+   TObj* obj;
+    if (!obj || !percentChance(50));
+    return false;
+    if ((obj->isObjStat(ITEM_SPIKED)) && victim->isTough()) {
+     int dam = number::(1,4);
+     obj->addCurrentStructPoints(-dam);
+     obj->addMaxStructPoints(-1);
+      if obj->getMaxStructPoints() <= 0) {
+       obj-makeBroken();
+       act("$p shatters as its spikes break off!", false, ch, obj, TO_ROOM);
+       return DELETE_OBJ;
+      }
+    auto* weapon = dynamic_cast<TGenWeapon*>(obj);
+       weapon->addCurrentSharp(-dam);
+       weapon->addMaxSharp(-1);
+        if (weapon->getMaxSharp() <= 0) {
+         weapon->makeBroken();
+         act("$p shatters as its spikes break off!", false, ch, obj, TO_ROOM);
+        return DELETE_OBJ;
+        }
+      }
+    act("The impact of the blow degrades the quality of your $o.", false, thief, obj, TO_CHAR);
+    if (!obj || percentChance(25)) {
+      obj->removeObjStat(ITEM_SPIKED);
+      act("The jagged spikes fall from $o. It no longer looks as brutal as it did before.", false, thief, obj, TO_CHAR);
+    }
+    }
+    */

--- a/code/code/misc/trap.cc
+++ b/code/code/misc/trap.cc
@@ -3895,8 +3895,10 @@ int TBeing::getGrenadeTrapDam(doorTrapT trap_type) {
   // i kept the damage on them lower then other traps.
   // this is number of d8 to use when calculating damage
   // base range: 5 - 30
+  // getSkillLevel refers to PC level (1-50)
   int damage = 5 + getSkillLevel(SKILL_SET_TRAP_GREN) / 2;
 
+//getGrenadeTrapLearn refers to skill learnedness (1-100)
   damage *= getGrenadeTrapLearn(trap_type);
   damage /= 100;
 

--- a/code/code/obj/obj_base_weapon.cc
+++ b/code/code/obj/obj_base_weapon.cc
@@ -1469,7 +1469,7 @@ int TBaseWeapon::catchSmack(TBeing* ch, TBeing** targ, TRoom* rp, int cdist,
               act("In the distance, $p embeds itself in $N.", TRUE, ch, this,
                 tb, TO_CHAR);
             if (spec)
-              checkSpec(ch, CMD_ARROW_EMBED, "", NULL);
+              checkSpec(tb, CMD_ARROW_EMBED, "", NULL);
           } else {
             if (!ch->sameRoom(*tb))
               act("In the distance, $N is hit by $p.", TRUE, ch, this, tb,

--- a/code/code/obj/obj_bow.cc
+++ b/code/code/obj/obj_bow.cc
@@ -199,7 +199,7 @@ void TBow::bloadArrowBow(TBeing* ch, TArrow* the_arrow) {
 
   --(*this);
   ch->equipChar(this, ch->getPrimaryHold());
-
+  this->checkSpec(ch, CMD_BLOAD, "", NULL);
   ch->addToWait(combatRound(1.5));
 }
 

--- a/code/code/obj/obj_general_weapon.cc
+++ b/code/code/obj/obj_general_weapon.cc
@@ -163,5 +163,19 @@ bool TGenWeapon::canBackstab() const {
 }
 
 bool TGenWeapon::canStab() const {
-  return isPierceWeapon() && getVolume() <= 2000;
+  return isPierceWeapon() && getVolume() <= 2500;
 }
+ bool TGenWeapon::isSpear() const {
+  return isPaired() && isPierceWeapon() && getVolume() <= 4500;
+ }
+
+ bool TGenWeapon::canSap() const {
+  return isBluntWeapon() && getVolume() <= 2500;
+ }
+
+ bool TGenWeapon::canHamstring() const {
+  return isSlashWeapon() && getVolume() <= 2500;
+ }
+ bool TGenWeapon::hasSpikes() const {
+  return isObjStat(ITEM_SPIKED);
+ }

--- a/code/code/obj/obj_general_weapon.h
+++ b/code/code/obj/obj_general_weapon.h
@@ -34,6 +34,10 @@ class TGenWeapon : public TBaseWeapon {
     virtual bool canCudgel() const;
     virtual bool canBackstab() const;
     virtual bool canStab() const;
+    virtual bool isSpear() const;
+    virtual bool canSap() const;
+    virtual bool canHamstring() const;
+    virtual bool hasSpikes() const;
 
     TGenWeapon();
     TGenWeapon(const TGenWeapon& a);

--- a/code/code/obj/obj_pool.cc
+++ b/code/code/obj/obj_pool.cc
@@ -249,6 +249,8 @@ bool TPool::isPluralItem() const {
   return TBaseCup::isPluralItem();
 }
 
+
+
 int TRoom::dropPool(int amt, liqTypeT liq) {
   TPool* pool = NULL;
   TThing* t = NULL;
@@ -257,7 +259,7 @@ int TRoom::dropPool(int amt, liqTypeT liq) {
   if (amt == 0)
     return FALSE;
 
-  /* look for preexisting pool */
+  //// look for preexisting pool
   for (StuffIter it = stuff.begin(); it != stuff.end() && (t = *it); ++it) {
     TPool* tp = dynamic_cast<TPool*>(t);
     if (tp && (tp->getDrinkType() == liq)) {
@@ -265,7 +267,6 @@ int TRoom::dropPool(int amt, liqTypeT liq) {
       break;
     }
   }
-
   if (!pool) {
     // create new pool
 #if 1

--- a/code/code/obj/obj_trap.cc
+++ b/code/code/obj/obj_trap.cc
@@ -372,3 +372,11 @@ int TTrap::throwMe(TBeing* ch, dirTypeT dir, const char*) {
   }
   return FALSE;
 }
+
+bool TTrap::isGrenade() const {
+  return getTrapEffectType() == 14;
+}
+
+bool TTrap::isLandMine() const {
+  return getTrapEffectType() == 1;
+}

--- a/code/code/obj/obj_trap.h
+++ b/code/code/obj/obj_trap.h
@@ -59,8 +59,14 @@ class TTrap : public TObj {
     void setTrapCharges(int r);
     int getTrapDamAmount() const;
 
+    virtual bool isGrenade() const;
+    virtual bool isLandMine() const;
+
+
     TTrap();
     TTrap(const TTrap& a);
     TTrap& operator=(const TTrap& a);
     virtual ~TTrap();
+
+
 };

--- a/code/code/spec/spec_objs.h
+++ b/code/code/spec/spec_objs.h
@@ -36,7 +36,7 @@ const int SPEC_FACTIONSCORE_BOARD = 97;
 const int SPEC_GRAFFITI = 135;
 const int SPEC_STOCK_BOARD = 138;
 const int SPEC_BRICKQUEST = 148;
-const int NUM_OBJ_SPECIALS = 163;
+const int NUM_OBJ_SPECIALS = 165;
 
 struct TObjSpecs {
     bool assignable;

--- a/code/code/spec/spec_objs_icydeath.cc
+++ b/code/code/spec/spec_objs_icydeath.cc
@@ -1,0 +1,332 @@
+#include <stdio.h>
+
+#include "being.h"
+#include "comm.h"
+#include "extern.h"
+#include "obj_base_weapon.h"
+
+int ColdHit(TBeing* ch, TBeing* vict, TObj* obj, int level) {
+  TObj* icicle = read_object(31349, REAL);
+  /*
+  Damage is slightly higher than a standard proc and based on wielder level
+  If damage is beyond a threshold, the proc gives an affect that reduces
+  victim's immunity to cold. This is meant to be the basis of a compound tactic
+  that capitalizes on a single high-risk/high-reward Cold damage spell-like
+  attack Given the level dependence of the damage spread of the onHit proc, it
+  will apply 11% of the time at level 10, and roughly 55% of the time at
+  level 50. The second part of the onHit
+  */
+  int dam = ::number(2 + level / 10, 10 + level / 10);
+  if (dam <= 11) {
+    act("$p becomes covered with ice and freezes $n.", 0, vict, obj, 0, TO_ROOM,
+      ANSI_CYAN);
+    act("$p becomes covered with ice and freezes you.", 0, vict, obj, 0,
+      TO_CHAR, ANSI_CYAN);
+  } else {
+    act("$p becomes covered with ice and sends a violent chill through $n.",
+      false, vict, obj, nullptr, TO_ROOM, ANSI_BLUE);
+    act("$p becomes covered with ice and sends a violent chill through you.",
+      false, vict, obj, nullptr, TO_CHAR, ANSI_BLUE);
+
+    affectedData aff;
+    aff.type = SPELL_FROST_BREATH;
+    aff.level = level;
+    aff.duration = level / 2 * Pulse::UPDATES_PER_MUDHOUR;
+    aff.modifier = -(level / 5);
+    aff.location = APPLY_IMMUNITY;
+    aff.bitvector = IMMUNE_COLD;
+    vict->affectTo(&aff);
+
+    if (dam >= 15) {
+      wearSlotT limb = vict->getRandomPart(PART_MISSING);
+      act(
+        "<C>The air around $p becomes an<1> <W>arctic blizzard,<1> <C>which "
+        "freezes $n to $s core!<1>",
+        false, vict, obj, nullptr, TO_ROOM, ANSI_BLUE);
+      act(
+        "<C>The air around $p becomes an<1> <W>arctic blizzard,<1> <C>which "
+        "freezes you to your core!<1>",
+        false, vict, obj, nullptr, TO_CHAR, ANSI_BLUE);
+      if (!vict->isImmune(IMMUNE_COLD, WEAR_BODY)) {
+        vict->stickIn(icicle, limb);
+        act(
+          "A chunk of $N's blood is frozen solid, leaving behind a jagged "
+          "<W>icicle<1>.",
+          false, vict, obj, nullptr, TO_NOTVICT);
+        act(
+          "A chunk of your blood is frozen solid, leaving behind a jagged "
+          "<W>icicle<1>.",
+          false, vict, obj, nullptr, TO_VICT);
+      }
+    }
+  }
+  int rc = ch->reconcileDamage(vict, dam, DAMAGE_FROST);
+  if (rc == -1)
+    return DELETE_VICT;
+  return TRUE;}
+
+int ColdShroud(TBeing* ch, TObj* obj, int level) {
+  affectedData aff1;
+  affectedData aff2;
+
+  ch = dynamic_cast<TBeing*>(obj->equippedBy);
+  // This applies a level based immunity to cold, which tops out at 35%
+  aff1.type = SPELL_PROTECTION_FROM_WATER;
+  aff1.duration = Pulse::UPDATES_PER_MUDHOUR * 3;
+  aff1.location = APPLY_IMMUNITY;
+  aff1.modifier = IMMUNE_COLD;
+  aff1.modifier2 = ((level * 7) / 10);
+  aff1.bitvector = 0;
+  aff1.level = 40;
+  act("A frigid wind emerges from $p and envelopes $N.", false, ch, nullptr,
+    nullptr, TO_ROOM, ANSI_BLUE);
+  act("A frigid wind emerges from $p and envelopes you.", false, ch, obj,
+    nullptr, TO_CHAR, ANSI_BLUE);
+  if (ch->getImmunity(IMMUNE_COLD) >= 100) {
+    // ARMOR APPLY
+    // checks for the wielder's immunity to cold and if it is 100% it applies
+    // a level based AC bonus
+    aff2.type = SPELL_PROTECTION_FROM_WATER;
+    aff2.level = 30;
+    aff2.duration = 3 * Pulse::UPDATES_PER_MUDHOUR;
+    aff2.location = APPLY_ARMOR;
+    aff2.modifier = -(25 + (level / 2));
+  }
+  act("The air around $N coallesces into a layer of protective frost.", false,
+    ch, nullptr, nullptr, TO_ROOM, ANSI_CYAN);
+  act("The air around you coallesces into a layer of protective frost.", false,
+    nullptr, nullptr, nullptr, TO_CHAR, ANSI_CYAN);
+
+    return true;
+}
+
+int coldBlast(TBeing* ch, TBeing* vict, TObj* obj, int level,
+  int coldimmunity) {
+  TObj* icicle = read_object(31349, REAL);
+
+  if (ch->checkObjUsed(obj)) {
+    act("You cannot use $p's powers again this soon.", TRUE, ch, obj, NULL,
+      TO_CHAR, NULL);
+    return FALSE;
+  }
+
+  if (!(vict = ch->fight())) {
+    act("You cannot use $p's powers unless you are fighting.", TRUE, ch, obj,
+      NULL, TO_CHAR, NULL);
+    return FALSE;
+  }
+
+  if (vict->isImmune(IMMUNE_COLD, WEAR_BODY)) {
+    act("You cannot use $p's powers on someone who is immune to cold.", TRUE,
+      ch, obj, NULL, TO_CHAR, NULL);
+    return FALSE;
+  }
+
+  ch->addObjUsed(obj, 3 * Pulse::UPDATES_PER_MUDHOUR);
+  int manaSpent = ch->getMana();
+  ch->addToMana(-manaSpent);
+  int dam = 0;
+  dam = manaSpent * (coldimmunity / 80);
+  dam = dam * (level / 50);
+ 
+  act(
+    "A storm blooms as you call out to the ancient souls of those taken "
+    "by the brutal cold!",
+    false, nullptr, nullptr, nullptr, TO_CHAR, ANSI_BLUE);
+  act(
+    "A storm blooms as $n calls out to the ancient souls of those taken "
+    "by the brutal cold!",
+    false, ch, nullptr, nullptr, TO_ROOM, ANSI_BLUE);
+
+  act(
+    "Howling winds erupt from$p, pummeling into $N's body with intense "
+    "fury!",
+    false, nullptr, obj, vict, TO_ROOM, ANSI_BLUE);
+  act(
+    "Howling winds erupt from $p, pummeling into your body with intense "
+    "fury!",
+    false, nullptr, obj, vict, TO_VICT, ANSI_BLUE);
+  act(
+    "Howling winds erupt from $p, pummeling into $N's body with intense "
+    "fury!",
+    false, nullptr, obj, vict, TO_CHAR, ANSI_BLUE);
+  int rc = ch->reconcileDamage(vict, dam, DAMAGE_FROST);
+    if (rc == -1)
+     return DELETE_VICT;
+    return TRUE;
+  if (manaSpent >= 300) {
+    affectedData aff;
+    aff.type = SKILL_DOORBASH;
+    aff.duration = Pulse::TICK * 4;
+    aff.bitvector = AFF_STUNNED;
+    vict->affectTo(&aff, -1);
+
+    if (vict->riding) {
+      vict->dismount(POSITION_STUNNED);
+      return true;
+    }
+
+    if (manaSpent >= 400) {
+      vict->cantHit += vict->loseRound(3 + (coldimmunity / 50));
+      act("The storm rages around $N, freezing $M to the core!", false, nullptr,
+        obj, vict, TO_ROOM, ANSI_BLUE_BOLD);
+      act("The storm rages around you, freezing you to the core!", false,
+        nullptr, obj, vict, TO_VICT, ANSI_BLUE_BOLD);
+    }
+
+    if (manaSpent >= 500) {
+      int numLimbs = ::number(manaSpent / 100 - 2, manaSpent / 100 + 2);
+      std::vector<wearSlotT> validLimbs;
+
+      for (wearSlotT limb; limb < MAX_WEAR; limb++) {
+        if (vict->hasPart(limb) && !vict->equipment[limb] &&
+            !vict->getStuckIn(limb)) {
+          validLimbs.push_back(limb);
+        }
+      }
+
+      while (numLimbs > 0 && !validLimbs.empty()) {
+        unsigned int index = ::number(0, validLimbs.size() - 1);
+        wearSlotT limb = validLimbs[index];
+        sstring buf = format(
+                        "<B>The icy winds tear into $N, battering their %s "
+                        "with<1> <W>shards of ice!<1>") %
+                      vict->describeBodySlot(limb);
+        act(buf, false, vict, nullptr, nullptr, TO_ROOM);
+        buf = format(
+                        "<B>The icy winds tear into you, battering your %s "
+                        "with<1> <W>shards of ice!<1>") %
+                      vict->describeBodySlot(limb);
+        act(buf, false, vict, nullptr, nullptr, TO_VICT);
+
+        vict->hurtLimb(::number(manaSpent / 100, manaSpent / 100 + 10), limb);
+
+        if (manaSpent >= 600) {
+          vict->stickIn(icicle, limb, SILENT_YES);
+          sstring buf =
+            format("<W>An icicle<1> <C>embeds itself into $N's %s!<1>") %
+            vict->describeBodySlot(limb);
+          act(buf, false, vict, nullptr, nullptr, TO_ROOM);
+          buf =
+            format("<W>An icicle<1> <C>embeds itself into your %s!<1>") %
+            vict->describeBodySlot(limb);
+          act(buf, false, vict, nullptr, nullptr, TO_VICT);
+        }
+
+        --numLimbs;
+
+        if (index != validLimbs.size() - 1) {
+          std::swap(validLimbs[index], validLimbs.back());
+        }
+        validLimbs.pop_back();
+      }
+    }
+  }
+  if (!ch || !percentChance(manaSpent / 60)) {
+    return false;
+    int rc = ch->reconcileDamage(ch, dam, DAMAGE_TRAP_PIERCE);
+    act(
+      "Deadly shards of ice tear through your flesh, impaling you "
+      "from "
+      "within.",
+      FALSE, ch, nullptr, nullptr, TO_CHAR, ANSI_BLUE_BOLD);
+
+    act(
+      "Jagged shards of ice explode from within $n's body, impaling "
+      "them  in a bloody spray.",
+      FALSE, ch, nullptr, nullptr, TO_ROOM, ANSI_BLUE_BOLD);
+
+    if (IS_SET_DELETE(rc, DELETE_VICT)) {
+      vict->reformGroup();
+      delete vict;
+      vict = NULL;
+    }
+  }
+  return true;
+}
+
+
+int coldThief(TBeing* ch, TBeing* vict, TObj* obj, int level) {
+  TObj* icicle = read_object(31349, REAL);
+  int rc = false;
+  wearSlotT limb = WEAR_BACK;
+  if (vict->isImmune(IMMUNE_COLD, WEAR_BODY) && ::number(0, 1))
+    return false;
+
+  int dam = 0;
+
+  dam = level * 3;
+  act("<W>$p turns bright white and freezes down $N's spine!<z>", false,
+    nullptr, obj, vict, TO_CHAR);
+  act("<W>$p turns bright white and freezes down $N's spine!<z>", false,
+    nullptr, obj, vict, TO_ROOM);
+  act("<W>$p turns bright white and freezes down your spine!<z>", false,
+    nullptr, obj, vict, TO_VICT);
+
+  rc = ch->reconcileDamage(vict, dam, DAMAGE_FROST);
+  if (rc == -1)
+    return DELETE_VICT;
+  return TRUE;
+
+  if (vict->slotChance(limb) && !vict->equipment[limb] &&
+      !vict->getStuckIn(limb)) {
+    act(
+      "$p freezes as it pierces $N's %s, leaving behind a jagged "
+      "icicle!<z>",
+      false, vict, obj, nullptr, TO_ROOM, ANSI_BLUE_BOLD);
+    act("$p freezes as it pierces your %s, leaving behind a jagged icicle!",
+      false, vict, obj, nullptr, TO_VICT, ANSI_BLUE_BOLD);
+    act(
+      "Your $p freezes as it pierces $N's %s, leaving behind a jagged "
+      "icicle!",
+      false, vict, obj, nullptr, TO_CHAR, ANSI_BLUE_BOLD);
+    vict->stickIn(icicle, limb);
+  }
+  return true;
+}
+int icyDeath(TBeing* vict, cmdTypeT cmd, const char* arg, TObj* obj, TObj*) {
+  TBeing* ch = dynamic_cast<TBeing*>(obj->equippedBy);
+  if (!ch)
+    return FALSE;  
+  int rc;
+  int level = ch->GetMaxLevel();
+  int coldimmunity = ch->getImmunity(IMMUNE_COLD);
+  rc = false;
+  int dam = 0;
+  if (cmd == CMD_OBJ_HIT && vict && percentChance(20)) {
+    ColdHit(ch, vict, obj, level);
+    rc = ch->reconcileDamage(vict, dam, DAMAGE_FROST);
+    if (IS_SET_DELETE(rc, DELETE_VICT)) {
+      vict->reformGroup();
+      delete vict;
+      vict = NULL;
+    }
+  }
+
+  if (cmd == CMD_GENERIC_PULSE && percentChance(5)) {
+    ColdShroud(ch, obj, level);
+    return true;
+  }
+
+  if (cmd == (CMD_SAY) || cmd == (CMD_SAY2)) {
+    sstring buf, buf2;
+    TBeing* vict = NULL;
+    buf = sstring(arg).word(0);
+    buf2 = sstring(arg).word(1);
+    int dam = 0;
+
+    if (buf == "winter" && buf2 == "cometh") {
+      coldBlast(ch, vict, obj, level, coldimmunity);
+      rc = ch->reconcileDamage(vict, dam, DAMAGE_FROST);
+      if (IS_SET_DELETE(rc, DELETE_VICT)) {
+        return DELETE_VICT;
+      }
+      return false;
+    }
+  }
+
+  if (cmd == CMD_BACKSTAB) {
+    coldThief(ch, vict, obj, level);
+  }
+  return false;
+}

--- a/code/code/spec/spec_objs_thief_quest.cc
+++ b/code/code/spec/spec_objs_thief_quest.cc
@@ -41,8 +41,8 @@ int thiefQuestWeapon(TBeing* victim, cmdTypeT command, const char* arg,
       limb == MAX_WEAR)
     return false;
 
-  // 10% chance on stab, 50% on backstab/slit
-  if (command == CMD_STAB && ::number(0, 9))
+  // 12.5% chance on stab, 50% on backstab/slit
+  if (command == CMD_STAB && ::number(0, 7))
     return false;
 
   if (::number(0, 1))

--- a/code/code/task/task_rest.cc
+++ b/code/code/task/task_rest.cc
@@ -11,8 +11,22 @@
 #include "room.h"
 #include "connect.h"
 
+
 int task_rest(TBeing* ch, cmdTypeT cmd, const char* arg, int pulse, TRoom*,
   TObj*) {
+  int mod = 1;
+  if (ch->inCamp()) {
+    mod *= 1.3;
+  }
+  if (ch->hasClass(CLASS_THIEF) && ch->isAffected(SKILL_CONCEALMENT)) {
+    mod *= 1.5;
+  }
+  if (ch->roomp->hasMobToCuddle()) {
+    mod *= 1.3;
+  }
+  if (ch->roomp->hasCampfire()) {
+    mod *= 1.3;
+  }
   if (ch->isLinkdead() || (ch->getPosition() != POSITION_RESTING)) {
     ch->stopTask();
     return FALSE;
@@ -38,13 +52,13 @@ int task_rest(TBeing* ch, cmdTypeT cmd, const char* arg, int pulse, TRoom*,
                   "Your lack of activity drains your precious lifeforce.\n\r");
               }
             } else {
-              ch->addToHit(1);
+              ch->addToHit(1*mod);
             }
           } else {
-            ch->addToHit(1);
+            ch->addToHit(1*mod);
           }
           if (ch->getMove() < ch->moveLimit())
-            ch->addToMove(1);
+            ch->addToMove(1*mod);
           if (ch->desc && ch->ansi()) {
             ch->desc->updateScreenAnsi(CHANGED_HP);
             ch->desc->updateScreenAnsi(CHANGED_MANA);

--- a/code/code/task/task_sleep.cc
+++ b/code/code/task/task_sleep.cc
@@ -10,13 +10,22 @@
 
 int task_sleep(TBeing* ch, cmdTypeT cmd, const char* arg, int pulse, TRoom*,
   TObj*) {
+  int mod = 1;
   if (ch->isLinkdead() || (ch->getPosition() != POSITION_SLEEPING)) {
     ch->stopTask();
     return FALSE;
   }
   if (ch->utilityTaskCommand(cmd))
     return FALSE;
-
+  if (ch->inCamp()) {
+    mod *= 1.5;
+  }
+  if (ch->roomp->hasMobToCuddle()) {
+    mod *= 1.5;
+  }
+  if (ch->roomp->hasCampfire()) {
+    mod *= 1.5;
+  }
   int regentime = ch->regenTime();
   switch (cmd) {
     case CMD_TASK_CONTINUE:
@@ -35,13 +44,13 @@ int task_sleep(TBeing* ch, cmdTypeT cmd, const char* arg, int pulse, TRoom*,
                 ch->addToLifeforce(-1);
               }
             } else {
-              ch->addToHit(1);
+              ch->addToHit(1*mod);
             }
           } else {
-            ch->addToHit(1);
+            ch->addToHit(1*mod);
           }
           if (ch->getMove() < ch->moveLimit())
-            ch->addToMove(1);
+            ch->addToMove(1*mod);
 
           if (ch->ansi()) {
             ch->desc->updateScreenAnsi(CHANGED_HP);

--- a/lib/zonefiles/15950
+++ b/lib/zonefiles/15950
@@ -427,182 +427,217 @@ O 0 14300 1 15995  load Dolgan's glowing stone for the shed
 ******Mobs******
 ****************
 
+Adding 16454 ('a cloak of iron-bound mail')
+Adding 16455 ('an iron-bound shield')
+Adding 16456 ('an iron-bound ring')
+Adding 16457 ('a legging of iron-bound mail')
+Adding 16458 ('a bracer of iron-bound mail')
+Adding 16459 ('a belt of iron-bound mail')
+Adding 16460 ('a glove of iron-bound mail')
+Not found: 16461
+Adding 16462 ('a sleeve of iron-bound mail')
+Adding 16463 ('a hauberk of iron-bound mail')
+Adding 16464 ('an iron-bound collar')
+Adding 16465 ('a coif of iron-bound mail')
+
+*local set - Ladybirds
+X 1  1    16456 'an iron-bound ring')
+X 1  2    16456 'an iron-bound ring')
+X 1  3    16464 'an iron-bound collar'
+X 1  4     16463 'a hauberk of iron-bound mail'
+X 1  5   16465 'a coif of iron-bound mail'
+X 1  6   16457 'a legging of iron-bound mail'
+X 1  7   16457 'a legging of iron-bound mail')
+X 1  8   16467 'an iron-bound boot'
+X 1  9   16467 'an iron-bound boot'
+X 1  10  16460 'a glove of iron-bound mail'
+X 1  11  16460 'a glove of iron-bound mail'
+X 1  12  16462 'a sleeve of iron-bound mail'
+X 1  13  16462 'a sleeve of iron-bound mail'
+X 1  14  16454 'a cloak of iron-bound mail'
+X 1  15  16459 'a belt of iron-bound mail'
+X 1  16  16458 'a bracer of iron-bound mail')
+X 1  17  16458 'a bracer of iron-bound mail')
+X 
+
 M 0 15954 2 15975 scholar library gnome male [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15955 2 15958 scholar library gnome female [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15954 2 15963 scholar library gnome male [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15955 2 15982 scholar library gnome female [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 
 M 0 15956 2 15975 scholar library elf male elven [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15958 2 15958 scholar library elf female elven [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15956 2 15977 scholar library elf male elven [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15958 2 15970 scholar library elf female elven [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 
 M 0 15957 4 15963 scholar library tired human male [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15957 4 15984 scholar library tired human male [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15957 4 15979 scholar library tired human male [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15957 4 15972 scholar library tired human male [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 
 M 0 15964 4 15969 scholar library tired human female [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15964 4 15977 scholar library tired human female [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15964 4 15976 scholar library tired human female [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15964 4 15972 scholar library tired human female [nocturnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 
 M 0 15963 4 15963 scholar library busy human male [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15963 4 15969 scholar library busy human male [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15963 4 15983 scholar library busy human male [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15963 4 15976 scholar library busy human male [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 
 M 0 15969 4 15976 scholar library busy human female [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15969 4 15977 scholar library busy human female [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15969 4 15972 scholar library busy human female [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 M 0 15969 4 15991 scholar library busy human female [diurnal]
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 
 M 0 15959 1 15963 scholar library human male Quentin insane
-? 0 3 0 E
-E 1 15962 32 5		3% cap of insanity
-? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15967 32 5		3% cap of insanity
+? 0 5 0 E
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 
 M 0 15960 1 15950 beggar pathetic Burdok
-? 0 3 0 E
-E 1 15967 32 14		3% tattered old cloak (of disguise)
+? 0 5 0 E
+E 1 15962 32 14		3% tattered old cloak (of disguise)
 
 
 M 0 15961 1 15951 library warder guard
-Y 0 8 3  		3% chance at loading some studded leather
+Y 0 60 4 			; Obsidian Scale Armor Set
 M 0 15961 2 15960 library warder guard
-Y 0 8 3  		3% chance at loading some studded leather
+Y 0 60 4 			; Obsidian Scale Armor Set
 M 0 15961 1 15970 library warder guard
-Y 0 8 3  		3% chance at loading some studded leather
+Y 0 60 4 			; Obsidian Scale Armor Set
 M 0 15961 1 15981 library warder guard
-Y 0 8 3  		3% chance at loading some studded leather
+Y 0 60 4 			; Obsidian Scale Armor Set
 
 
 M 0 15962 1 15961 Library warder guard captain Vassus impressive
-Y 0 10 4  		4% chance at loading some metal
+Y 0 60 4 			; Obsidian Scale Armor Set
+? 0 5 0 E
+E 1 7016 1 18 		obsidian mining hammer
 
 
 M 0 15965 1 15995 groundskeeper keeper Willon disgruntled
@@ -619,9 +654,9 @@ E 1 15981 9999 18 	4% pen glass slender
 ? 0 4 0 G
 G 1 15980 9999		4% case scrollcase ivory
 ? 0 1 0 E
-E 1 15964 200 1		1% ring silver gold flecked
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+E 1 15964 200 1		5% ring silver gold flecked
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 
 M 0 15967 1 15980 Assistant librarian Agorix library
@@ -632,40 +667,40 @@ E 1 15979 9999 19 	4% glass magnifying
 E 1 15981 9999 18 	4% pen glass slender
 ? 0 4 0 G
 G 1 15980 9999		4% case scrollcase ivory
-? 0 2 0 E
+? 0 5 0 E
 E 1 15954 16 5 		2% circlet meditation golden
-? 0 1 0 E
-E 1 15968 200 2		1% ring greenish copper
+? 0 5 0 E
+E 1 15968 200 2		5% ring greenish copper
 
 
 M 0 15968 1 15989 Devarsi shaman researcher elf elven
-? 0 1 0 E
-E 1 15952 16 16		1% bracelet ravens silver
-? 0 1 0 E
-E 1 15952 16 17		1% bracelet ravens silver
+? 0 5 0 E
+E 1 15952 16 16		5% bracelet ravens silver
+? 0 5 0 E
+E 1 15952 16 17		5% bracelet ravens silver
 
 
 M 0 15970 1 15978 Krug ogre researcher
-? 0 25 0 E
-E 1 15983 1 18 		25% book iron-bound nursery rhyme [no-rent]
+? 0 5 0 E
+E 1 15983 1 18 		book iron-bound nursery rhyme
 
 
 M 0 15971 1 15988 Tyra human female researcher woman
-? 0 1 0 E
-E 1 15953 16 12		1% armband ivory beasts animals ornate
-? 0 1 0 E
-E 1 15953 16 13		1% armband ivory beasts animals ornate
+? 0 5 0 E
+E 1 15953 16 12		5% armband ivory beasts animals ornate
+? 0 5 0 E
+E 1 15953 16 13		5% armband ivory beasts animals ornate
 
 
 M 0 15972 1 15985 Tormod dwarf dwarven researcher
-? 0 1 0 E
-E 1 15955 16 10		1% gauntlet prayer
-? 0 1 0 E
-E 1 15955 16 11		1% gauntlet prayer
+? 0 5 0 E
+E 1 15955 16 10		5% gauntlet prayer
+? 0 5 0 E
+E 1 15955 16 11		5% gauntlet prayer
 
 
 M 0 15973 1 15990 Gnayana gnome gnomish researcher
-? 0 2 0 E
+? 0 5 0 E
 E 1 15961 16 15		2% belt tiger's eye brown
 
 


### PR DESCRIPTION
In this drop:

Adding new functions for all existing trap types. Enriching some existing effects like frostengulfed to now add a frostbite disease to wet targets. Throwing filled liquid containers, some spells, and other liquid-based interaction will now apply a Wet effect.

Normalizing stat check functions to allow for manipulation of stats via existing state-based affects to allow for additional avenues toward skill success. Enriching some existing effects like frostengulfed to now add a frostbite disease to 

Thieves with the appropriate skills will now be able to harvest trap components from disarmed traps.

Adding a new thief skill, Sap, which functions similarly to backstab, but which is acquired later. It is a strength based blunt surprise attack intended to injure the victim's arms, wrists, or hands.

Adding normalized spike behavior for skills and altering some existing skills to specify limbs, in order that spike behavior might also add bleeding. The thief stab Skill is rewritten to be more reliable in combat, and to allow for two-handed pierce weapons.

Adding object procs that will become available with upcoming thief skills which will add spikes to objects, set fire to arrows, poison arrows, and create caltrop-like hazards.

Hide is being altered to now provide feedback for when the hide condition is removed. Some changes made to the list of commands which will exit Hide. Notably, Rest will no longer interrupt hide.

The Rest task will now update PC's upon entering rest about how their regen is being boosted. Camping, campfires, companions, and other factors will now allow for a slight boost to regen modifier.



